### PR TITLE
Fix initial RPTracker update

### DIFF
--- a/cogs/RPTracker.py
+++ b/cogs/RPTracker.py
@@ -48,6 +48,7 @@ class RPTracker(commands.Cog):
 
     async def initial_setup(self):
         logger.info("Début du setup initial")
+        await self.bot.wait_until_ready()
         await self.check_and_update()
         logger.info("Setup initial terminé")
 


### PR DESCRIPTION
## Summary
- ensure RPTracker waits for the bot to be ready before calling `check_and_update`

## Testing
- `python -m py_compile $(find . -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_6840d9d4e3708323b67ace66ee1f24c9