### PR TITLE
Add simple daily card draw webapp

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,0 +1,22 @@
+# Webapp de tirage quotidien
+
+Cette application Flask est un exemple simplifié du système de tirage de cartes
+présent sur le bot Discord. Elle fonctionne indépendamment du reste du projet.
+
+## Installation rapide
+
+1. Installez les dépendances :
+   ```bash
+   pip install flask requests
+   ```
+2. Créez une application Discord pour obtenir `DISCORD_CLIENT_ID` et
+   `DISCORD_CLIENT_SECRET`. Définissez aussi `DISCORD_REDIRECT_URI` dans les
+   variables d'environnement ainsi qu'une `FLASK_SECRET` quelconque.
+3. Lancez le serveur :
+   ```bash
+   python app.py
+   ```
+4. Ouvrez `http://localhost:5000` et connectez‑vous avec Discord pour effectuer
+   votre tirage quotidien.
+
+Les données utilisateurs sont stockées localement dans `users.json`.

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,131 @@
+import os
+import json
+from datetime import datetime
+from flask import Flask, redirect, request, session, url_for, render_template, jsonify
+import requests
+
+app = Flask(__name__)
+app.secret_key = os.environ.get('FLASK_SECRET', 'changeme')
+
+# Discord OAuth2 configuration
+CLIENT_ID = os.environ.get('DISCORD_CLIENT_ID')
+CLIENT_SECRET = os.environ.get('DISCORD_CLIENT_SECRET')
+REDIRECT_URI = os.environ.get('DISCORD_REDIRECT_URI', 'http://localhost:5000/callback')
+API_BASE_URL = 'https://discord.com/api'
+
+# Load sample cards
+with open(os.path.join(os.path.dirname(__file__), 'cards.json'), encoding='utf-8') as f:
+    CARDS = json.load(f)
+
+RARITY_WEIGHTS = {
+    "Secrète": 0.005,
+    "Fondateur": 0.01,
+    "Historique": 0.02,
+    "Maître": 0.06,
+    "Black Hole": 0.06,
+    "Architectes": 0.07,
+    "Professeurs": 0.1167,
+    "Autre": 0.2569,
+    "Élèves": 0.4203,
+}
+ALL_CATEGORIES = list(RARITY_WEIGHTS.keys())
+
+USERS_FILE = os.path.join(os.path.dirname(__file__), 'users.json')
+if not os.path.exists(USERS_FILE):
+    with open(USERS_FILE, 'w') as f:
+        json.dump({}, f)
+
+
+def load_users():
+    with open(USERS_FILE, 'r') as f:
+        return json.load(f)
+
+
+def save_users(data):
+    with open(USERS_FILE, 'w') as f:
+        json.dump(data, f)
+
+
+def draw_cards(n=3):
+    import random
+    drawn = []
+    weights = [RARITY_WEIGHTS[c] for c in ALL_CATEGORIES]
+    total = sum(weights)
+    weights = [w / total for w in weights]
+    for _ in range(n):
+        cat = random.choices(ALL_CATEGORIES, weights=weights, k=1)[0]
+        options = CARDS.get(cat, [])
+        if not options:
+            continue
+        card = random.choice(options)
+        drawn.append({'category': cat, 'name': card})
+    return drawn
+
+
+@app.route('/')
+def index():
+    user = session.get('user')
+    return render_template('index.html', user=user)
+
+
+@app.route('/login')
+def login():
+    discord_url = (
+        f"{API_BASE_URL}/oauth2/authorize?client_id={CLIENT_ID}"
+        f"&redirect_uri={REDIRECT_URI}"
+        f"&response_type=code&scope=identify"
+    )
+    return redirect(discord_url)
+
+
+@app.route('/callback')
+def callback():
+    code = request.args.get('code')
+    if not code:
+        return 'Missing code', 400
+    data = {
+        'client_id': CLIENT_ID,
+        'client_secret': CLIENT_SECRET,
+        'grant_type': 'authorization_code',
+        'code': code,
+        'redirect_uri': REDIRECT_URI,
+        'scope': 'identify'
+    }
+    headers = { 'Content-Type': 'application/x-www-form-urlencoded' }
+    token_res = requests.post(f'{API_BASE_URL}/oauth2/token', data=data, headers=headers)
+    token_res.raise_for_status()
+    tokens = token_res.json()
+    user_res = requests.get(
+        f'{API_BASE_URL}/users/@me',
+        headers={'Authorization': f"Bearer {tokens['access_token']}"}
+    )
+    user_res.raise_for_status()
+    user = user_res.json()
+    session['user'] = {'id': user['id'], 'username': f"{user['username']}#{user['discriminator']}"}
+    return redirect(url_for('index'))
+
+
+@app.route('/logout')
+def logout():
+    session.pop('user', None)
+    return redirect(url_for('index'))
+
+
+@app.route('/draw', methods=['POST'])
+def draw():
+    user = session.get('user')
+    if not user:
+        return jsonify({'error': 'not_logged_in'}), 401
+    users = load_users()
+    today = datetime.utcnow().date().isoformat()
+    last = users.get(user['id'], {}).get('last_draw')
+    if last == today:
+        return jsonify({'error': 'already_drawn'})
+    drawn = draw_cards()
+    users[user['id']] = {'last_draw': today, 'cards': drawn}
+    save_users(users)
+    return jsonify({'cards': drawn})
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/cards.json
+++ b/webapp/cards.json
@@ -1,0 +1,11 @@
+{
+  "Secrète": ["Carte Mystère"],
+  "Fondateur": ["Les Créateurs"],
+  "Historique": ["Ancienne Légende"],
+  "Maître": ["Haut Maître"],
+  "Black Hole": ["Trou Noir"],
+  "Architectes": ["Bâtisseur"],
+  "Professeurs": ["Enseignant"],
+  "Autre": ["Aventurier", "Gardien"],
+  "Élèves": ["Novice", "Apprenti", "Étudiant"]
+}

--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('draw-form');
+    if (!form) return;
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const res = await fetch('/draw', { method: 'POST' });
+        const data = await res.json();
+        const container = document.getElementById('results');
+        container.innerHTML = '';
+        if (data.error) {
+            container.textContent = data.error === 'already_drawn' ?
+                'Tirage déjà effectué aujourd\'hui.' : 'Erreur.';
+            return;
+        }
+        data.cards.forEach(card => {
+            const div = document.createElement('div');
+            div.className = 'card';
+            div.innerHTML = `\n<div class="card-inner">\n  <div class="card-front">?\uD83C\uDCCF</div>\n  <div class="card-back"><strong>${card.name}</strong><br>${card.category}</div>\n</div>`;
+            container.appendChild(div);
+            setTimeout(() => div.classList.add('flip'), 100);
+        });
+    });
+});

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,0 +1,63 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f5f5;
+    text-align: center;
+    margin-top: 50px;
+}
+.container {
+    width: 80%;
+    margin: auto;
+}
+.login {
+    padding: 10px 20px;
+    background-color: #7289da;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 4px;
+}
+button {
+    padding: 10px 20px;
+    border: none;
+    background-color: #5865f2;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.results {
+    margin-top: 20px;
+    display: flex;
+    justify-content: center;
+}
+.card {
+    width: 150px;
+    height: 200px;
+    margin: 10px;
+    perspective: 1000px;
+}
+.card-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+}
+.card.flip .card-inner {
+    transform: rotateY(180deg);
+}
+.card-front, .card-back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+}
+.card-back {
+    transform: rotateY(180deg);
+    background: #e0e0e0;
+}

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Tirage quotidien</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        {% if user %}
+            <p>Connecté en tant que {{ user.username }}</p>
+            <form id="draw-form" method="post" action="/draw">
+                <button type="submit">Tirer mes cartes du jour</button>
+            </form>
+            <div id="results" class="results"></div>
+            <p><a href="/logout">Se déconnecter</a></p>
+        {% else %}
+            <a class="login" href="/login">Se connecter avec Discord</a>
+        {% endif %}
+    </div>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `webapp/` folder with Flask-based website
- implement Discord OAuth login and daily card draw logic
- include minimal HTML/CSS/JS for card flip animation
- provide README with setup instructions

## Testing
- `python -m py_compile webapp/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68437f2b9a088323a3d3c97fbceebcc4