### PR TITLE
Add Google Sheets integration to webapp

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,0 +1,33 @@
+# Webapp de tirage quotidien
+
+Cette application Flask est un exemple simplifié du système de tirage de cartes
+présent sur le bot Discord. Elle peut maintenant se connecter au même Google
+Sheet que le bot et annoncer les tirages dans un salon Discord.
+
+## Installation rapide
+
+1. Installez les dépendances :
+   ```bash
+   pip install flask requests gspread google-auth
+   ```
+2. Créez une application Discord pour obtenir `DISCORD_CLIENT_ID` et
+   `DISCORD_CLIENT_SECRET`. Définissez aussi `DISCORD_REDIRECT_URI` dans les
+   variables d'environnement ainsi qu'une `FLASK_SECRET` quelconque. Le bot
+   doit disposer d'un token (`DISCORD_TOKEN`) capable d'envoyer des messages
+   dans le salon d'annonce (`DISCORD_CHANNEL_ID`, par défaut `1361993326215172218`).
+3. Définissez les variables pour l'accès à Google Sheets :
+   `SERVICE_ACCOUNT_JSON` (contenu JSON de votre compte de service) et
+   `GOOGLE_SHEET_ID_CARTES`.
+4. Lancez le serveur :
+   ```bash
+   python app.py
+   ```
+5. Ouvrez `http://localhost:5000` et connectez‑vous avec Discord pour effectuer
+   votre tirage quotidien.
+
+Les tirages sont inscrits dans le même Google Sheet que le bot Discord et un
+message récapitulatif est envoyé dans le salon configuré.
+
+Pour l'hébergement, n'importe quelle plateforme supportant Python (Render,
+Railway, un serveur personnel…) peut convenir. Il suffit de définir les
+variables d'environnement ci-dessus.

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,206 @@
+import os
+import json
+from datetime import datetime
+from flask import Flask, redirect, request, session, url_for, render_template, jsonify
+import requests
+import gspread
+from google.oauth2.service_account import Credentials
+
+app = Flask(__name__)
+app.secret_key = os.environ.get('FLASK_SECRET', 'changeme')
+
+# Discord OAuth2 configuration
+CLIENT_ID = os.environ.get('DISCORD_CLIENT_ID')
+CLIENT_SECRET = os.environ.get('DISCORD_CLIENT_SECRET')
+REDIRECT_URI = os.environ.get('DISCORD_REDIRECT_URI', 'http://localhost:5000/callback')
+API_BASE_URL = 'https://discord.com/api'
+
+# Load sample cards
+with open(os.path.join(os.path.dirname(__file__), 'cards.json'), encoding='utf-8') as f:
+    CARDS = json.load(f)
+
+RARITY_WEIGHTS = {
+    "Secrète": 0.005,
+    "Fondateur": 0.01,
+    "Historique": 0.02,
+    "Maître": 0.06,
+    "Black Hole": 0.06,
+    "Architectes": 0.07,
+    "Professeurs": 0.1167,
+    "Autre": 0.2569,
+    "Élèves": 0.4203,
+}
+ALL_CATEGORIES = list(RARITY_WEIGHTS.keys())
+
+# Google Sheets configuration (shared with the Discord bot)
+SCOPES = [
+    'https://www.googleapis.com/auth/spreadsheets',
+    'https://www.googleapis.com/auth/drive'
+]
+
+def get_sheets():
+    """Return (sheet_cards, sheet_daily_draw) using environment credentials."""
+    if not hasattr(app, 'sheet_cards'):
+        creds_info = os.environ.get('SERVICE_ACCOUNT_JSON')
+        if not creds_info:
+            raise RuntimeError('SERVICE_ACCOUNT_JSON is not configured')
+        creds = Credentials.from_service_account_info(json.loads(creds_info), scopes=SCOPES)
+        client = gspread.authorize(creds)
+        spreadsheet = client.open_by_key(os.environ['GOOGLE_SHEET_ID_CARTES'])
+        app.sheet_cards = spreadsheet.sheet1
+        try:
+            app.sheet_daily_draw = spreadsheet.worksheet('Tirages Journaliers')
+        except gspread.exceptions.WorksheetNotFound:
+            app.sheet_daily_draw = spreadsheet.add_worksheet(title='Tirages Journaliers', rows='1000', cols='2')
+    return app.sheet_cards, app.sheet_daily_draw
+def draw_cards(n=3):
+    import random
+    drawn = []
+    weights = [RARITY_WEIGHTS[c] for c in ALL_CATEGORIES]
+    total = sum(weights)
+    weights = [w / total for w in weights]
+    for _ in range(n):
+        cat = random.choices(ALL_CATEGORIES, weights=weights, k=1)[0]
+        options = CARDS.get(cat, [])
+        if not options:
+            continue
+        card = random.choice(options)
+        drawn.append({'category': cat, 'name': card})
+    return drawn
+
+
+def _merge_cells(row):
+    merged = {}
+    for cell in row[2:]:
+        cell = cell.strip()
+        if not cell or ':' not in cell:
+            continue
+        uid, cnt = cell.split(':', 1)
+        uid = uid.strip()
+        try:
+            cnt = int(cnt.strip())
+        except ValueError:
+            continue
+        merged[uid] = merged.get(uid, 0) + cnt
+    return row[:2] + [f"{uid}:{cnt}" for uid, cnt in merged.items()]
+
+
+def add_card_to_user(user_id, category, name):
+    sheet_cards, _ = get_sheets()
+    rows = sheet_cards.get_all_values()
+    for i, row in enumerate(rows):
+        if len(row) < 2:
+            continue
+        if row[0] == category and row[1] == name:
+            for j in range(2, len(row)):
+                cell = row[j].strip()
+                if cell.startswith(f"{user_id}:"):
+                    uid, count = cell.split(':', 1)
+                    uid = uid.strip()
+                    row[j] = f"{uid}:{int(count) + 1}"
+                    sheet_cards.update(f"A{i+1}", [_merge_cells(row)])
+                    return
+            row.append(f"{user_id}:1")
+            sheet_cards.update(f"A{i+1}", [_merge_cells(row)])
+            return
+    new_row = [category, name, f"{user_id}:1"]
+    sheet_cards.append_row(new_row)
+
+
+def record_daily_draw(user_id):
+    _, sheet_daily_draw = get_sheets()
+    today = datetime.utcnow().date().isoformat()
+    rows = sheet_daily_draw.get_all_values()
+    row_idx = next((i for i, r in enumerate(rows) if r and r[0] == str(user_id)), None)
+    if row_idx is not None and len(rows[row_idx]) > 1 and rows[row_idx][1] == today:
+        return False
+    if row_idx is None:
+        sheet_daily_draw.append_row([str(user_id), today])
+    else:
+        sheet_daily_draw.update(f"B{row_idx+1}", [[today]])
+    return True
+
+
+def send_discord_message(user, cards):
+    token = os.environ.get('DISCORD_TOKEN')
+    channel_id = os.environ.get('DISCORD_CHANNEL_ID', '1361993326215172218')
+    if not token:
+        return
+    content = f"{user['username']} a tir\u00e9 : " + \
+        ', '.join(f"{c['name']} ({c['category']})" for c in cards)
+    headers = {
+        'Authorization': f'Bot {token}',
+        'Content-Type': 'application/json'
+    }
+    requests.post(
+        f"{API_BASE_URL}/channels/{channel_id}/messages",
+        headers=headers,
+        json={'content': content}
+    )
+
+
+@app.route('/')
+def index():
+    user = session.get('user')
+    return render_template('index.html', user=user)
+
+
+@app.route('/login')
+def login():
+    discord_url = (
+        f"{API_BASE_URL}/oauth2/authorize?client_id={CLIENT_ID}"
+        f"&redirect_uri={REDIRECT_URI}"
+        f"&response_type=code&scope=identify"
+    )
+    return redirect(discord_url)
+
+
+@app.route('/callback')
+def callback():
+    code = request.args.get('code')
+    if not code:
+        return 'Missing code', 400
+    data = {
+        'client_id': CLIENT_ID,
+        'client_secret': CLIENT_SECRET,
+        'grant_type': 'authorization_code',
+        'code': code,
+        'redirect_uri': REDIRECT_URI,
+        'scope': 'identify'
+    }
+    headers = { 'Content-Type': 'application/x-www-form-urlencoded' }
+    token_res = requests.post(f'{API_BASE_URL}/oauth2/token', data=data, headers=headers)
+    token_res.raise_for_status()
+    tokens = token_res.json()
+    user_res = requests.get(
+        f'{API_BASE_URL}/users/@me',
+        headers={'Authorization': f"Bearer {tokens['access_token']}"}
+    )
+    user_res.raise_for_status()
+    user = user_res.json()
+    session['user'] = {'id': user['id'], 'username': f"{user['username']}#{user['discriminator']}"}
+    return redirect(url_for('index'))
+
+
+@app.route('/logout')
+def logout():
+    session.pop('user', None)
+    return redirect(url_for('index'))
+
+
+@app.route('/draw', methods=['POST'])
+def draw():
+    user = session.get('user')
+    if not user:
+        return jsonify({'error': 'not_logged_in'}), 401
+    if not record_daily_draw(user['id']):
+        return jsonify({'error': 'already_drawn'})
+    drawn = draw_cards()
+    for c in drawn:
+        add_card_to_user(user['id'], c['category'], c['name'])
+    send_discord_message(user, drawn)
+    return jsonify({'cards': drawn})
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/cards.json
+++ b/webapp/cards.json
@@ -1,0 +1,11 @@
+{
+  "Secrète": ["Carte Mystère"],
+  "Fondateur": ["Les Créateurs"],
+  "Historique": ["Ancienne Légende"],
+  "Maître": ["Haut Maître"],
+  "Black Hole": ["Trou Noir"],
+  "Architectes": ["Bâtisseur"],
+  "Professeurs": ["Enseignant"],
+  "Autre": ["Aventurier", "Gardien"],
+  "Élèves": ["Novice", "Apprenti", "Étudiant"]
+}

--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('draw-form');
+    if (!form) return;
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const res = await fetch('/draw', { method: 'POST' });
+        const data = await res.json();
+        const container = document.getElementById('results');
+        container.innerHTML = '';
+        if (data.error) {
+            container.textContent = data.error === 'already_drawn' ?
+                'Tirage déjà effectué aujourd\'hui.' : 'Erreur.';
+            return;
+        }
+        data.cards.forEach(card => {
+            const div = document.createElement('div');
+            div.className = 'card';
+            div.innerHTML = `\n<div class="card-inner">\n  <div class="card-front">?\uD83C\uDCCF</div>\n  <div class="card-back"><strong>${card.name}</strong><br>${card.category}</div>\n</div>`;
+            container.appendChild(div);
+            setTimeout(() => div.classList.add('flip'), 100);
+        });
+    });
+});

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,0 +1,63 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f5f5;
+    text-align: center;
+    margin-top: 50px;
+}
+.container {
+    width: 80%;
+    margin: auto;
+}
+.login {
+    padding: 10px 20px;
+    background-color: #7289da;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 4px;
+}
+button {
+    padding: 10px 20px;
+    border: none;
+    background-color: #5865f2;
+    color: white;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.results {
+    margin-top: 20px;
+    display: flex;
+    justify-content: center;
+}
+.card {
+    width: 150px;
+    height: 200px;
+    margin: 10px;
+    perspective: 1000px;
+}
+.card-inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    transition: transform 0.6s;
+    transform-style: preserve-3d;
+}
+.card.flip .card-inner {
+    transform: rotateY(180deg);
+}
+.card-front, .card-back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    backface-visibility: hidden;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+}
+.card-back {
+    transform: rotateY(180deg);
+    background: #e0e0e0;
+}

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Tirage quotidien</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        {% if user %}
+            <p>Connecté en tant que {{ user.username }}</p>
+            <form id="draw-form" method="post" action="/draw">
+                <button type="submit">Tirer mes cartes du jour</button>
+            </form>
+            <div id="results" class="results"></div>
+            <p><a href="/logout">Se déconnecter</a></p>
+        {% else %}
+            <a class="login" href="/login">Se connecter avec Discord</a>
+        {% endif %}
+    </div>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- connect webapp to Google Sheets using the same credentials as the Discord bot
- send drawn cards to a Discord channel
- document new environment variables and hosting notes

## Testing
- `python -m py_compile webapp/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68437f2b9a088323a3d3c97fbceebcc4