### PR TITLE
Implement action list for scene todo

### DIFF
--- a/cogs/scene_todo.py
+++ b/cogs/scene_todo.py
@@ -1,201 +1,337 @@
 import discord
-from discord.ext import commands, tasks
+from discord.ext import commands
 from discord import app_commands
 from datetime import datetime
 import json
 import os
 
-SCENES_FILE = "scenes.json"
-
+SCENE_CHANNEL_ID = 1380704586016362626
+LOG_CHANNEL_ID = 1097883902279946360
 MJ_ROLE_ID = 1018179623886000278
+SCENES_FILE = "scenes.json"
+EMBED_COLOR = 0x6d5380
 
-class AddSceneModal(discord.ui.Modal, title="Nouvelle scène"):
-    def __init__(self, cog, guild: discord.Guild):
+
+class AddSceneModal(discord.ui.Modal, title="Créer une scène"):
+    def __init__(self, cog: "SceneTodo"):
         super().__init__()
         self.cog = cog
-        self.guild = guild
-        self.mj_input = discord.ui.TextInput(
-            label="MJ responsable",
-            placeholder="Nom du MJ",
-            required=True,
+        self.mj_input = discord.ui.TextInput(label="MJ responsable", required=True)
+        self.name_input = discord.ui.TextInput(label="Nom de la scène", required=True)
+        self.actions_input = discord.ui.TextInput(
+            label="Actions initiales (une par ligne)",
+            style=discord.TextStyle.paragraph,
+            required=False,
         )
-        self.name = discord.ui.TextInput(label="Nom de la scène", required=True)
         self.add_item(self.mj_input)
-        self.add_item(self.name)
+        self.add_item(self.name_input)
+        self.add_item(self.actions_input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        await interaction.response.defer(ephemeral=True)
-        scene = self.cog.add_scene(self.mj_input.value.strip(), self.name.value)
+        await interaction.response.defer(thinking=False)
+        channel = self.cog.bot.get_channel(SCENE_CHANNEL_ID)
+        if not channel:
+            return
+        actions = [a.strip() for a in self.actions_input.value.splitlines() if a.strip()]
+        await self.cog.create_scene(
+            channel,
+            self.name_input.value.strip(),
+            self.mj_input.value.strip(),
+            actions,
+        )
 
-        self.cog.track_message(interaction.message)
-        await self.cog.refresh_message(interaction.message)
 
-class CompleteSceneButton(discord.ui.Button):
-    def __init__(self, cog, scene_id: int, label: str):
-        super().__init__(label=label, style=discord.ButtonStyle.success, custom_id=f"complete_{scene_id}")
+class ActionButton(discord.ui.Button):
+    def __init__(self, cog: "SceneTodo", scene_id: int, action: dict):
+        style = discord.ButtonStyle.success if action.get("done") else discord.ButtonStyle.secondary
+        super().__init__(
+            label=action["label"],
+            style=style,
+            custom_id=f"scene_{scene_id}_action_{action['id']}",
+            disabled=action.get("done", False),
+        )
+        self.cog = cog
+        self.scene_id = scene_id
+        self.action_id = action["id"]
+
+    async def callback(self, interaction: discord.Interaction):
+        if not any(r.id == MJ_ROLE_ID for r in interaction.user.roles):
+            await interaction.response.send_message("Permission refusée.")
+            return
+        scene = self.cog.get_scene(self.scene_id)
+        if not scene:
+            await interaction.response.send_message("Scène introuvable.")
+            return
+        action = self.cog.toggle_action(self.scene_id, self.action_id)
+        if not action:
+            await interaction.response.send_message("Action introuvable.")
+            return
+        await interaction.response.defer(thinking=False)
+        await self.cog.refresh_scene_message(scene)
+        if action.get("done"):
+            await self.cog.log_action_done(scene, action, interaction.user)
+
+
+class CompleteButton(discord.ui.Button):
+    def __init__(self, cog: "SceneTodo", scene_id: int, disabled: bool):
+        super().__init__(
+            label="Scène terminée",
+            style=discord.ButtonStyle.success,
+            custom_id=f"scene_done_{scene_id}",
+            disabled=disabled,
+        )
         self.cog = cog
         self.scene_id = scene_id
 
     async def callback(self, interaction: discord.Interaction):
+        if not any(r.id == MJ_ROLE_ID for r in interaction.user.roles):
+            await interaction.response.send_message("Permission refusée.")
+            return
         scene = self.cog.get_scene(self.scene_id)
         if not scene:
-            await interaction.response.send_message("Scène inconnue.", ephemeral=True)
+            await interaction.response.send_message("Scène introuvable.")
             return
-        if not any(r.id == MJ_ROLE_ID for r in interaction.user.roles):
-            await interaction.response.send_message("Permission refusée.", ephemeral=True)
+        if scene.get("completed"):
+            await interaction.response.send_message("Scène déjà terminée.")
             return
-        self.cog.complete_scene(self.scene_id)
-        await interaction.response.send_message(f"Scène '{scene['name']}' terminée.", ephemeral=True)
-        await self.cog.announce_completion(interaction.guild, scene)
-        self.cog.track_message(interaction.message)
-        await self.cog.refresh_message(interaction.message)
+        await self.cog.finish_scene(scene)
+        await interaction.response.defer(thinking=False)
 
-class ScenesView(discord.ui.View):
-    def __init__(self, cog):
+
+class DeleteSceneButton(discord.ui.Button):
+    def __init__(self, cog: "SceneTodo", scene_id: int):
+        super().__init__(
+            label="Supprimer",
+            style=discord.ButtonStyle.danger,
+            custom_id=f"scene_del_{scene_id}",
+        )
+        self.cog = cog
+        self.scene_id = scene_id
+
+    async def callback(self, interaction: discord.Interaction):
+        if not any(r.id == MJ_ROLE_ID for r in interaction.user.roles):
+            await interaction.response.send_message("Permission refusée.")
+            return
+        scene = self.cog.delete_scene(self.scene_id)
+        if not scene:
+            await interaction.response.send_message("Scène introuvable.")
+            return
+        await interaction.response.defer(thinking=False)
+        channel = self.cog.bot.get_channel(SCENE_CHANNEL_ID)
+        if channel:
+            try:
+                msg = await channel.fetch_message(scene["message_id"])
+                await msg.delete()
+            except discord.NotFound:
+                pass
+
+
+class SceneView(discord.ui.View):
+    def __init__(self, cog: "SceneTodo", scene: dict):
+        super().__init__(timeout=None)
+        for action in scene.get("actions", []):
+            self.add_item(ActionButton(cog, scene["id"], action))
+        self.add_item(CompleteButton(cog, scene["id"], scene.get("completed", False)))
+        self.add_item(DeleteSceneButton(cog, scene["id"]))
+
+
+class AddSceneView(discord.ui.View):
+    def __init__(self, cog: "SceneTodo"):
         super().__init__(timeout=None)
         self.cog = cog
         self.add_item(AddSceneButton(cog))
-        for scene in cog.get_active_scenes():
-            label = f"✔ {scene['name']}"
-            self.add_item(CompleteSceneButton(cog, scene['id'], label))
+
 
 class AddSceneButton(discord.ui.Button):
-    def __init__(self, cog):
-        super().__init__(label="Ajouter une scène", style=discord.ButtonStyle.primary, custom_id="add_scene")
+    def __init__(self, cog: "SceneTodo"):
+        super().__init__(label="Ajouter une scène", style=discord.ButtonStyle.primary, custom_id="create_scene")
         self.cog = cog
 
     async def callback(self, interaction: discord.Interaction):
-        modal = AddSceneModal(self.cog, interaction.guild)
-        await interaction.response.send_modal(modal)
+        if not any(r.id == MJ_ROLE_ID for r in interaction.user.roles):
+            await interaction.response.send_message("Permission refusée.")
+            return
+        await interaction.response.send_modal(AddSceneModal(self.cog))
+
 
 class SceneTodo(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         data = self.load_data()
         self.scenes = data.get("scenes", [])
-        self.message_info = data.get("message")
-        self.update_loop.start()
+        self.init_message_id = data.get("init_message")
+        self.bot.loop.create_task(self.initialize())
 
-    def cog_unload(self):
-        self.update_loop.cancel()
-
-    def track_message(self, message: discord.Message):
-        self.message_info = {"channel_id": message.channel.id, "message_id": message.id}
-        self.save_data()
-
-    @tasks.loop(hours=1)
-    async def update_loop(self):
-        if not self.message_info:
-            return
-        channel = self.bot.get_channel(self.message_info["channel_id"])
-        if channel:
-            try:
-                message = await channel.fetch_message(self.message_info["message_id"])
-                await self.refresh_message(message)
-            except discord.NotFound:
-                self.message_info = None
-                self.save_data()
-
-    @update_loop.before_loop
-    async def before_update_loop(self):
-        await self.bot.wait_until_ready()
-
-    # --------- Persistence ---------
+    # ---------------- Persistence ----------------
     def load_data(self):
         if os.path.isfile(SCENES_FILE):
-            with open(SCENES_FILE, 'r', encoding='utf-8') as f:
+            with open(SCENES_FILE, "r", encoding="utf-8") as f:
                 data = json.load(f)
-                if isinstance(data, list):
-                    return {"scenes": data, "message": None}
-                return data
-        return {"scenes": [], "message": None}
+            if isinstance(data, list):
+                data = {"scenes": data, "init_message": None}
+            if "message" in data and "init_message" not in data:
+                data["init_message"] = data["message"]
+            for scene in data.get("scenes", []):
+                scene.setdefault("completed", False)
+                scene.setdefault("actions", [])
+            return data
+        return {"scenes": [], "init_message": None}
 
     def save_data(self):
-        with open(SCENES_FILE, 'w', encoding='utf-8') as f:
-            json.dump({"scenes": self.scenes, "message": self.message_info}, f, ensure_ascii=False, indent=2)
+        with open(SCENES_FILE, "w", encoding="utf-8") as f:
+            json.dump({"scenes": self.scenes, "init_message": self.init_message_id}, f, ensure_ascii=False, indent=2)
 
-    # --------- Scene Operations ---------
-    def add_scene(self, mj_name: str, name: str):
-        scene_id = max([s['id'] for s in self.scenes], default=0) + 1
-        scene = {
-            "id": scene_id,
-            "name": name,
-            "mj": mj_name,
-            "created_at": datetime.utcnow().isoformat(),
-            "completed": False,
-        }
-        self.scenes.append(scene)
-        self.save_data()
-        return scene
-
+    # ---------------- Utility ----------------
     def get_scene(self, scene_id: int):
         for s in self.scenes:
             if s["id"] == scene_id:
                 return s
         return None
 
-    def complete_scene(self, scene_id: int):
+    def add_action(self, scene_id: int, label: str):
         scene = self.get_scene(scene_id)
-        if scene and not scene.get("completed"):
-            scene["completed"] = True
-            self.save_data()
+        if not scene:
+            return None
+        action_id = max([a["id"] for a in scene.get("actions", [])], default=0) + 1
+        action = {"id": action_id, "label": label, "done": False}
+        scene.setdefault("actions", []).append(action)
+        self.save_data()
+        return action
+
+    def toggle_action(self, scene_id: int, action_id: int):
+        scene = self.get_scene(scene_id)
+        if not scene:
+            return None
+        for action in scene.get("actions", []):
+            if action["id"] == action_id:
+                action["done"] = not action.get("done", False)
+                self.save_data()
+                return action
+        return None
+
+
+    def delete_scene(self, scene_id: int):
+        for i, scene in enumerate(self.scenes):
+            if scene["id"] == scene_id:
+                removed = self.scenes.pop(i)
+                self.save_data()
+                return removed
+        return None
+
+    def build_scene_embed(self, scene: dict) -> discord.Embed:
+        created = datetime.fromisoformat(scene["created_at"]).strftime("%d/%m/%Y")
+        desc = f"MJ responsable : {scene['mj']}\nCréée le {created}"
+        actions = scene.get("actions", [])
+        if actions:
+            for act in actions:
+                status = "✅" if act.get("done") else "⬜️"
+                desc += f"\n{status} {act['label']}"
+        if scene.get("completed"):
+            desc += "\n✅ Scène terminée"
+        return discord.Embed(title=scene["name"], description=desc, color=EMBED_COLOR)
+
+    async def log_action_done(self, scene: dict, action: dict, user: discord.User):
+        channel = self.bot.get_channel(LOG_CHANNEL_ID)
+        if channel:
+            await channel.send(
+                f"📌 Action **{action['label']}** complétée pour la scène **{scene['name']}** (MJ : {scene['mj']}) par {user.mention}"
+            )
+
+    async def log_completion(self, scene: dict):
+        channel = self.bot.get_channel(LOG_CHANNEL_ID)
+        if channel:
+            await channel.send(f"✅ Scène **{scene['name']}** terminée (MJ : {scene['mj']})")
+
+    async def refresh_scene_message(self, scene: dict):
+        channel = self.bot.get_channel(SCENE_CHANNEL_ID)
+        if not channel:
+            return
+        try:
+            message = await channel.fetch_message(scene["message_id"])
+        except discord.NotFound:
+            return
+        view = SceneView(self, scene)
+        await message.edit(embed=self.build_scene_embed(scene), view=view)
+        self.bot.add_view(view, message_id=message.id)
+
+    # ---------------- Scene operations ----------------
+    async def create_scene(self, channel: discord.TextChannel, name: str, mj: str, actions: list[str]):
+        scene_id = max([s["id"] for s in self.scenes], default=0) + 1
+        scene = {
+            "id": scene_id,
+            "name": name,
+            "mj": mj,
+            "created_at": datetime.utcnow().isoformat(),
+            "completed": False,
+            "message_id": None,
+            "actions": [],
+        }
+        for i, label in enumerate(actions, start=1):
+            scene["actions"].append({"id": i, "label": label, "done": False})
+        view = SceneView(self, scene)
+        message = await channel.send(embed=self.build_scene_embed(scene), view=view)
+        self.bot.add_view(view, message_id=message.id)
+        scene["message_id"] = message.id
+        self.scenes.append(scene)
+        self.save_data()
         return scene
 
-    def get_active_scenes(self):
-        return [s for s in self.scenes if not s.get("completed")]
+    async def finish_scene(self, scene: dict):
+        scene["completed"] = True
+        self.save_data()
+        await self.refresh_scene_message(scene)
+        await self.log_completion(scene)
 
-    # --------- Helper ---------
-    def format_time_ago(self, iso_time: str) -> str:
-        try:
-            dt = datetime.fromisoformat(iso_time)
-        except Exception:
-            return "?"
-        diff = datetime.utcnow() - dt
-        total_hours = diff.days * 24 + diff.seconds // 3600
-        days, hours = divmod(total_hours, 24)
-        parts = []
-        if days:
-            parts.append(f"{days} jour{'s' if days > 1 else ''}")
-        if hours or not parts:
-            parts.append(f"{hours} heure{'s' if hours > 1 else ''}")
-        return " et ".join(parts)
+    # ---------------- Initialization ----------------
+    async def initialize(self):
+        await self.bot.wait_until_ready()
+        await self.ensure_init_message()
+        await self.restore_scene_views()
 
-    def build_embed(self):
-        embed = discord.Embed(title="Scènes en cours", color=discord.Color.blurple())
-        scenes = self.get_active_scenes()
-        if not scenes:
-            embed.description = "Aucune scène en cours."
-            return embed
-        for scene in scenes:
-            since = self.format_time_ago(scene["created_at"])
-            mj_name = scene.get("mj", "?")
-            embed.add_field(name=scene["name"], value=f"MJ : {mj_name}\nDepuis {since}", inline=False)
-        return embed
-
-    async def refresh_message(self, message: discord.Message):
-        try:
-            await message.edit(embed=self.build_embed(), view=ScenesView(self))
-        except discord.NotFound:
-            pass
-
-    async def announce_completion(self, guild: discord.Guild, scene: dict):
-        channel_id = int(os.getenv("SCENE_TODO_CHANNEL_ID", 0))
-        if not channel_id:
+    async def ensure_init_message(self):
+        channel = self.bot.get_channel(SCENE_CHANNEL_ID)
+        if not channel:
             return
-        channel = guild.get_channel(channel_id)
-        if channel:
-            mj_name = scene.get("mj", "?")
-            await channel.send(f"✅ La scène **{scene['name']}** menée par {mj_name} est terminée.")
+        if self.init_message_id:
+            try:
+                message = await channel.fetch_message(self.init_message_id)
+                view = AddSceneView(self)
+                await message.edit(view=view)
+                self.bot.add_view(view, message_id=message.id)
+                return
+            except discord.NotFound:
+                self.init_message_id = None
+        embed = discord.Embed(title="Gestion des scènes", description="Utilisez le bouton ci-dessous pour créer une nouvelle scène.", color=EMBED_COLOR)
+        view = AddSceneView(self)
+        message = await channel.send(embed=embed, view=view)
+        self.bot.add_view(view, message_id=message.id)
+        self.init_message_id = message.id
+        self.save_data()
 
-    # --------- Commands ---------
-    @app_commands.command(name="scenes", description="Gérer la to-do list des scènes")
-    async def scenes_cmd(self, interaction: discord.Interaction):
-        embed = self.build_embed()
-        view = ScenesView(self)
-        await interaction.response.send_message(embed=embed, view=view)
-        msg = await interaction.original_response()
-        self.track_message(msg)
+    async def restore_scene_views(self):
+        channel = self.bot.get_channel(SCENE_CHANNEL_ID)
+        if not channel:
+            return
+        for scene in self.scenes:
+            try:
+                message = await channel.fetch_message(scene["message_id"])
+            except discord.NotFound:
+                continue
+            view = SceneView(self, scene)
+            await message.edit(embed=self.build_scene_embed(scene), view=view)
+            self.bot.add_view(view, message_id=message.id)
+
+    # ---------------- Commands ----------------
+    @app_commands.command(name="scenes-init", description="Réinitialiser le message de création de scènes")
+    async def scenes_init(self, interaction: discord.Interaction):
+        if not any(r.id == MJ_ROLE_ID for r in interaction.user.roles):
+            await interaction.response.send_message("Permission refusée.")
+            return
+        await self.ensure_init_message()
+        await interaction.response.send_message("Message initial prêt.")
+
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(SceneTodo(bot))
     print("Cog scene_todo chargé avec succès")
+

--- a/scenes.json
+++ b/scenes.json
@@ -1,1 +1,1 @@
-{"scenes": [], "message": null}
+{"scenes": [], "init_message": null}


### PR DESCRIPTION
## Summary
- add textarea for actions when creating a scene
- implement buttons per action with completion toggles
- store actions in `scenes.json` and migrate old data
- show actions with checkmarks in scene embeds

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_6844354eae408323993dc4313c5284e4