### PR TITLE
Simplify scene todo actions

### DIFF
--- a/cogs/scene_todo.py
+++ b/cogs/scene_todo.py
@@ -18,58 +18,38 @@ class AddSceneModal(discord.ui.Modal, title="Créer une scène"):
         self.cog = cog
         self.mj_input = discord.ui.TextInput(label="MJ responsable", required=True)
         self.name_input = discord.ui.TextInput(label="Nom de la scène", required=True)
-        self.actions_input = discord.ui.TextInput(
-            label="Actions initiales (une par ligne)",
-            style=discord.TextStyle.paragraph,
-            required=False,
-        )
         self.add_item(self.mj_input)
         self.add_item(self.name_input)
-        self.add_item(self.actions_input)
+        
 
     async def on_submit(self, interaction: discord.Interaction):
         await interaction.response.defer(thinking=False)
         channel = self.cog.bot.get_channel(SCENE_CHANNEL_ID)
         if not channel:
             return
-        actions = [a.strip() for a in self.actions_input.value.splitlines() if a.strip()]
         await self.cog.create_scene(
             channel,
             self.name_input.value.strip(),
             self.mj_input.value.strip(),
-            actions,
         )
 
 
 class ActionButton(discord.ui.Button):
-    def __init__(self, cog: "SceneTodo", scene_id: int, action: dict):
-        style = discord.ButtonStyle.success if action.get("done") else discord.ButtonStyle.secondary
+    def __init__(self, cog: "SceneTodo", scene_id: int):
         super().__init__(
-            label=action["label"],
-            style=style,
-            custom_id=f"scene_{scene_id}_action_{action['id']}",
-            disabled=action.get("done", False),
+            label="Action terminée",
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"scene_{scene_id}_action",
         )
         self.cog = cog
         self.scene_id = scene_id
-        self.action_id = action["id"]
 
     async def callback(self, interaction: discord.Interaction):
         if not any(r.id == MJ_ROLE_ID for r in interaction.user.roles):
             await interaction.response.send_message("Permission refusée.")
             return
-        scene = self.cog.get_scene(self.scene_id)
-        if not scene:
-            await interaction.response.send_message("Scène introuvable.")
-            return
-        action = self.cog.toggle_action(self.scene_id, self.action_id)
-        if not action:
-            await interaction.response.send_message("Action introuvable.")
-            return
         await interaction.response.defer(thinking=False)
-        await self.cog.refresh_scene_message(scene)
-        if action.get("done"):
-            await self.cog.log_action_done(scene, action, interaction.user)
+        await interaction.channel.send("Action terminée")
 
 
 class CompleteButton(discord.ui.Button):
@@ -129,8 +109,7 @@ class DeleteSceneButton(discord.ui.Button):
 class SceneView(discord.ui.View):
     def __init__(self, cog: "SceneTodo", scene: dict):
         super().__init__(timeout=None)
-        for action in scene.get("actions", []):
-            self.add_item(ActionButton(cog, scene["id"], action))
+        self.add_item(ActionButton(cog, scene["id"]))
         self.add_item(CompleteButton(cog, scene["id"], scene.get("completed", False)))
         self.add_item(DeleteSceneButton(cog, scene["id"]))
 
@@ -173,7 +152,6 @@ class SceneTodo(commands.Cog):
                 data["init_message"] = data["message"]
             for scene in data.get("scenes", []):
                 scene.setdefault("completed", False)
-                scene.setdefault("actions", [])
             return data
         return {"scenes": [], "init_message": None}
 
@@ -188,28 +166,6 @@ class SceneTodo(commands.Cog):
                 return s
         return None
 
-    def add_action(self, scene_id: int, label: str):
-        scene = self.get_scene(scene_id)
-        if not scene:
-            return None
-        action_id = max([a["id"] for a in scene.get("actions", [])], default=0) + 1
-        action = {"id": action_id, "label": label, "done": False}
-        scene.setdefault("actions", []).append(action)
-        self.save_data()
-        return action
-
-    def toggle_action(self, scene_id: int, action_id: int):
-        scene = self.get_scene(scene_id)
-        if not scene:
-            return None
-        for action in scene.get("actions", []):
-            if action["id"] == action_id:
-                action["done"] = not action.get("done", False)
-                self.save_data()
-                return action
-        return None
-
-
     def delete_scene(self, scene_id: int):
         for i, scene in enumerate(self.scenes):
             if scene["id"] == scene_id:
@@ -221,21 +177,9 @@ class SceneTodo(commands.Cog):
     def build_scene_embed(self, scene: dict) -> discord.Embed:
         created = datetime.fromisoformat(scene["created_at"]).strftime("%d/%m/%Y")
         desc = f"MJ responsable : {scene['mj']}\nCréée le {created}"
-        actions = scene.get("actions", [])
-        if actions:
-            for act in actions:
-                status = "✅" if act.get("done") else "⬜️"
-                desc += f"\n{status} {act['label']}"
         if scene.get("completed"):
             desc += "\n✅ Scène terminée"
         return discord.Embed(title=scene["name"], description=desc, color=EMBED_COLOR)
-
-    async def log_action_done(self, scene: dict, action: dict, user: discord.User):
-        channel = self.bot.get_channel(LOG_CHANNEL_ID)
-        if channel:
-            await channel.send(
-                f"📌 Action **{action['label']}** complétée pour la scène **{scene['name']}** (MJ : {scene['mj']}) par {user.mention}"
-            )
 
     async def log_completion(self, scene: dict):
         channel = self.bot.get_channel(LOG_CHANNEL_ID)
@@ -255,7 +199,7 @@ class SceneTodo(commands.Cog):
         self.bot.add_view(view, message_id=message.id)
 
     # ---------------- Scene operations ----------------
-    async def create_scene(self, channel: discord.TextChannel, name: str, mj: str, actions: list[str]):
+    async def create_scene(self, channel: discord.TextChannel, name: str, mj: str):
         scene_id = max([s["id"] for s in self.scenes], default=0) + 1
         scene = {
             "id": scene_id,
@@ -264,10 +208,7 @@ class SceneTodo(commands.Cog):
             "created_at": datetime.utcnow().isoformat(),
             "completed": False,
             "message_id": None,
-            "actions": [],
         }
-        for i, label in enumerate(actions, start=1):
-            scene["actions"].append({"id": i, "label": label, "done": False})
         view = SceneView(self, scene)
         message = await channel.send(embed=self.build_scene_embed(scene), view=view)
         self.bot.add_view(view, message_id=message.id)


### PR DESCRIPTION
## Summary
- remove action list concept from scene todo cog
- add generic `Action terminée` button usable infinitely
- drop action input in scene creation modal
- keep scene embeds minimal

## Testing
- `python -m py_compile main.py cogs/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68444d0e58708323a0b82216420ce574