### PR TITLE
Implement Google Sheets for scene persistence

### DIFF
--- a/cogs/README.md
+++ b/cogs/README.md
@@ -71,6 +71,15 @@ Cog probablement lié à un thème "espace" ou à une dimension narrative spéci
 
 ---
 
+## 📝 scene_todo.py
+Gestion d'une to-do list de scènes RP.
+- Stocke les scènes et l'identifiant du message d'initialisation dans Google Sheets.
+  - L'ID du message est conservé dans l'onglet `Config` (clé `init_message_id`)
+    et dans la colonne `init_message_id` de la feuille `Scenes`.
+- Utilise la variable d'environnement `SCENES_GOOGLE_SHEET_ID` pour sélectionner la feuille dédiée.
+
+---
+
 ## 🧼 bump.py
 Fonction pour le bump automatique ou assisté :
 - Relance de serveurs (type Disboard ?).

--- a/cogs/scene_todo.py
+++ b/cogs/scene_todo.py
@@ -4,12 +4,19 @@ from discord import app_commands
 from datetime import datetime
 import json
 import os
+import gspread
+from google.oauth2.service_account import Credentials
 
 SCENE_CHANNEL_ID = 1380704586016362626
 LOG_CHANNEL_ID = 1097883902279946360
 MJ_ROLE_ID = 1018179623886000278
-SCENES_FILE = "scenes.json"
 EMBED_COLOR = 0x6d5380
+SCOPES = [
+    'https://www.googleapis.com/auth/spreadsheets',
+    'https://www.googleapis.com/auth/drive'
+]
+
+
 
 
 class AddSceneModal(discord.ui.Modal, title="Créer une scène"):
@@ -136,28 +143,147 @@ class AddSceneButton(discord.ui.Button):
 class SceneTodo(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        self.gc = None
+        self.sheet_scenes = None
+        self.sheet_config = None
+        self.setup_google_sheets()
         data = self.load_data()
         self.scenes = data.get("scenes", [])
         self.init_message_id = data.get("init_message")
         self.bot.loop.create_task(self.initialize())
 
+    def setup_google_sheets(self):
+        sheet_id = os.getenv('SCENES_GOOGLE_SHEET_ID')
+        if not sheet_id:
+            print("SCENES_GOOGLE_SHEET_ID non défini")
+            return
+        try:
+            creds_info = json.loads(os.getenv('SERVICE_ACCOUNT_JSON'))
+            creds = Credentials.from_service_account_info(creds_info, scopes=SCOPES)
+            self.gc = gspread.authorize(creds)
+            spreadsheet = self.gc.open_by_key(sheet_id)
+            try:
+                self.sheet_scenes = spreadsheet.worksheet('Scenes')
+            except gspread.exceptions.WorksheetNotFound:
+                self.sheet_scenes = spreadsheet.sheet1
+            if not self.sheet_scenes.get_all_values():
+                self.sheet_scenes.update(
+                    'A1',
+                    [[
+                        "id",
+                        "name",
+                        "mj",
+                        "created_at",
+                        "completed",
+                        "message_id",
+                        "init_message_id",
+                    ]],
+                )
+            try:
+                self.sheet_config = spreadsheet.worksheet('Config')
+            except gspread.exceptions.WorksheetNotFound:
+                self.sheet_config = spreadsheet.add_worksheet(title='Config', rows='10', cols='2')
+                self.sheet_config.append_row(["key", "value"])
+        except Exception as e:
+            print(f"Erreur lors de la connexion à Google Sheets: {e}")
+            self.gc = None
+            self.sheet_scenes = None
+            self.sheet_config = None
+
     # ---------------- Persistence ----------------
     def load_data(self):
-        if os.path.isfile(SCENES_FILE):
-            with open(SCENES_FILE, "r", encoding="utf-8") as f:
-                data = json.load(f)
-            if isinstance(data, list):
-                data = {"scenes": data, "init_message": None}
-            if "message" in data and "init_message" not in data:
-                data["init_message"] = data["message"]
-            for scene in data.get("scenes", []):
-                scene.setdefault("completed", False)
-            return data
-        return {"scenes": [], "init_message": None}
+        if not self.sheet_scenes or not self.sheet_config:
+            return {"scenes": [], "init_message": None}
+
+        scenes = []
+        init_message = None
+        try:
+            rows = self.sheet_scenes.get_all_values()
+            header = rows[0] if rows else []
+            for idx, row in enumerate(rows[1:], start=1):
+                if (
+                    header
+                    and len(header) > 6
+                    and header[6] == "init_message_id"
+                    and idx == 1
+                    and len(row) > 6
+                ):
+                    value = row[6]
+                    if value:
+                        try:
+                            init_message = int(value)
+                        except ValueError:
+                            init_message = None
+                    continue
+                if not row or not row[0]:
+                    continue
+                scene = {
+                    "id": int(row[0]),
+                    "name": row[1],
+                    "mj": row[2],
+                    "created_at": row[3],
+                    "completed": row[4].lower() == "true",
+                    "message_id": int(row[5]) if len(row) > 5 and row[5] else None,
+                }
+                scenes.append(scene)
+        except Exception as e:
+            print(f"Erreur chargement scenes: {e}")
+
+        try:
+            records = self.sheet_config.get_all_records()
+            for rec in records:
+                if rec.get("key") == "init_message_id":
+                    value = rec.get("value")
+                    if value:
+                        try:
+                            init_message = int(value)
+                        except ValueError:
+                            init_message = None
+                    break
+        except Exception as e:
+            print(f"Erreur chargement config: {e}")
+
+        return {"scenes": scenes, "init_message": init_message}
 
     def save_data(self):
-        with open(SCENES_FILE, "w", encoding="utf-8") as f:
-            json.dump({"scenes": self.scenes, "init_message": self.init_message_id}, f, ensure_ascii=False, indent=2)
+        if not self.sheet_scenes or not self.sheet_config:
+            return
+
+        try:
+            rows = [[
+                "id",
+                "name",
+                "mj",
+                "created_at",
+                "completed",
+                "message_id",
+                "init_message_id",
+            ], ["", "", "", "", "", "", ""]]
+            for s in self.scenes:
+                rows.append([
+                    str(s["id"]),
+                    s["name"],
+                    s["mj"],
+                    s["created_at"],
+                    str(s.get("completed", False)),
+                    str(s.get("message_id", "")),
+                    "",
+                ])
+            self.sheet_scenes.clear()
+            self.sheet_scenes.update('A1', rows)
+            # Save init message ID in a dedicated column
+            self.sheet_scenes.update(
+                'G1:G2',
+                [["init_message_id"], [str(self.init_message_id or "")]],
+            )
+        except Exception as e:
+            print(f"Erreur sauvegarde scenes: {e}")
+
+        try:
+            self.sheet_config.clear()
+            self.sheet_config.update('A1', [["key", "value"], ["init_message_id", str(self.init_message_id or "")]])
+        except Exception as e:
+            print(f"Erreur sauvegarde config: {e}")
 
     # ---------------- Utility ----------------
     def get_scene(self, scene_id: int):


### PR DESCRIPTION
## Summary
- connect scene management cog to `SCENES_GOOGLE_SHEET_ID`
- fall back to the first worksheet when `Scenes` sheet isn't found
- save initialization message ID in the sheet so it's not resent on restart
- document where the message ID is stored in `cogs/README.md`

## Testing
- `pip install -q -r requirements.txt`
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_6844518ae6a48323a1ad572db709e084