### PR TITLE
Fix sorting order for scenes

### DIFF
--- a/cogs/scene_todo.py
+++ b/cogs/scene_todo.py
@@ -316,7 +316,7 @@ class SceneTodo(commands.Cog):
 
     def sort_scenes(self):
         self.scenes.sort(
-            key=lambda s: s.get("last_action", s.get("created_at")), reverse=True
+            key=lambda s: s.get("last_action", s.get("created_at")), reverse=False
         )
 
     def delete_scene(self, scene_id: int):


### PR DESCRIPTION
## Summary
- adjust sorting in `scene_todo.py` so older unanswered scenes appear first

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844799d9e40832385cd38f4c402ad9b