### PR TITLE
Add multi-card trading capability

### DIFF
--- a/cogs/README.md
+++ b/cogs/README.md
@@ -11,7 +11,7 @@ Gère le système de cartes à collectionner :
 - Galerie utilisateur.
 - Intégration avec Google Sheets.
 - Affichage des cartes et progression dans un mur.
-- Commandes : `/cartes`, `!tirage_journalier`, etc.
+- Commandes : `/cartes`, `!tirage_journalier`, `/echanger_cartes`, etc.
 
 ---
 


### PR DESCRIPTION
## Summary
- implement `safe_multi_exchange` helper to handle many-for-one trades
- add `/echanger_cartes` slash command for multi-card trades
- document new command in `cogs/README.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68448c82f6d083238e3695b63cb8aaa5