### PR TITLE
Reverse scene sorting

### DIFF
--- a/cogs/scene_todo.py
+++ b/cogs/scene_todo.py
@@ -316,7 +316,7 @@ class SceneTodo(commands.Cog):
 
     def sort_scenes(self):
         self.scenes.sort(
-            key=lambda s: s.get("last_action", s.get("created_at")), reverse=False
+            key=lambda s: s.get("last_action", s.get("created_at")), reverse=True
         )
 
     def delete_scene(self, scene_id: int):


### PR DESCRIPTION
## Summary
- invert ordering of scenes so the newest scenes appear first

## Testing
- `python -m py_compile cogs/scene_todo.py`
- `python - <<'EOF'
import sys, subprocess, pathlib
for p in pathlib.Path('.').rglob('*.py'):
    subprocess.check_call([sys.executable, '-m', 'py_compile', str(p)])
print('done')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684585453fe483238228c8f5c012c99a