### PR TITLE
Invert surveillance message order

### DIFF
--- a/cogs/Surveillance_scene.py
+++ b/cogs/Surveillance_scene.py
@@ -1655,7 +1655,11 @@ class SurveillanceScene(commands.Cog):
             logging.error(f"Erreur lors de la mise à jour du message de surveillance: {e}")
 
     async def reorder_surveillance_messages(self):
-        """Réordonne les messages de surveillance par date d'activité."""
+        """Réordonne les messages de surveillance par date d'activité.
+
+        Les scènes les moins actives sont affichées dans les messages les plus
+        récents du salon de surveillance.
+        """
         try:
             surveillance_channel = self.bot.get_channel(SURVEILLANCE_CHANNEL_ID)
             if not surveillance_channel:
@@ -1677,7 +1681,8 @@ class SurveillanceScene(commands.Cog):
                 except Exception:
                     return datetime.fromtimestamp(0, tz=self.paris_tz)
 
-            scenes.sort(key=activity_date)
+            # Place the least active scenes in the most recent messages
+            scenes.sort(key=activity_date, reverse=True)
             message_ids = sorted(int(s['message_id']) for s in scenes)
 
             for msg_id, scene in zip(message_ids, scenes):


### PR DESCRIPTION
## Summary
- Display least active scenes in most recent surveillance messages
- Update documentation for reorder_surveillance_messages

## Testing
- `python -m py_compile cogs/Surveillance_scene.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895031cc75c83238f74f307d781803d