### PR TITLE
Refactor inactive search for Discord inactivity tracker

### DIFF
--- a/cogs/InactiveUserTracker.py
+++ b/cogs/InactiveUserTracker.py
@@ -3,23 +3,23 @@ from discord.ext import commands
 import datetime
 import asyncio
 from typing import Dict, List, Optional
+import logging
+
+logger = logging.getLogger(__name__)
 
 class InactiveUserTracker(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.target_role_id = 1018442041241374762
-        # IDs des catégories à vérifier
         self.category_ids = [
             1240553817393594439,
             1175022020749168662,
             1020820787583799358,
             1017797004019105842
         ]
-        # ID du salon prioritaire
         self.priority_channel_id = 1124836464904118482
-        # Pour éviter les recherches simultanées
         self.is_searching = False
-    
+
     @commands.command(name='verifier_inactifs')
     @commands.has_permissions(administrator=True)
     async def check_inactive_users(self, ctx, max_days: Optional[int] = None, limit_days: Optional[int] = 180):
@@ -27,13 +27,13 @@ class InactiveUserTracker(commands.Cog):
         if self.is_searching:
             await ctx.send("Une recherche est déjà en cours. Veuillez attendre qu'elle se termine.")
             return
-            
+
         self.is_searching = True
         try:
             await self._perform_inactive_search(ctx, max_days, limit_days)
         finally:
             self.is_searching = False
-    
+
     async def _perform_inactive_search(self, ctx, max_days: Optional[int] = None, limit_days: Optional[int] = 180):
         embed = discord.Embed(
             title="Recherche d'inactivité",
@@ -41,269 +41,255 @@ class InactiveUserTracker(commands.Cog):
             color=discord.Color.blue()
         )
         status_message = await ctx.send(embed=embed)
-        
-        # Mise à jour régulière du message de statut
+
         update_task = asyncio.create_task(self._update_status_periodically(status_message))
-        
+
         try:
-            # Récupérer le rôle cible
             role = ctx.guild.get_role(self.target_role_id)
             if not role:
                 await self._update_status(status_message, "Erreur", f"Le rôle avec l'ID {self.target_role_id} n'a pas été trouvé.", discord.Color.red())
                 update_task.cancel()
                 return
-            
+
             members_with_role = [member for member in ctx.guild.members if role in member.roles]
             if not members_with_role:
                 await self._update_status(status_message, "Terminé", f"Aucun membre n'a le rôle {role.name}.", discord.Color.green())
                 update_task.cancel()
                 return
-            
-            await self._update_status(status_message, "En cours", 
-                f"Préparation de l'analyse pour {len(members_with_role)} membres avec le rôle {role.name}...", discord.Color.blue())
-            
-            # Dictionnaire pour stocker le dernier message de chaque membre
-            last_message_dates = {}
-            
-            # Calculer la date limite de recherche
-            cutoff_date = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=limit_days)
-            
-            # Obtenir tous les canaux textuels à vérifier
-            channels_to_check = []
-            thread_ids_checked = set()  # Pour éviter les doublons
-            
-            # D'abord ajouter le canal prioritaire s'il existe
-            priority_channel = ctx.guild.get_channel(self.priority_channel_id)
-            if priority_channel:
-                channels_to_check.append(priority_channel)
-            
-            # Ensuite, ajouter tous les autres canaux des catégories spécifiées
-            for category_id in self.category_ids:
-                category = ctx.guild.get_channel(category_id)
-                if category and isinstance(category, discord.CategoryChannel):
-                    await self._update_status(status_message, "En cours", 
-                        f"Listage des canaux de la catégorie {category.name}...", discord.Color.blue())
-                    
-                    for channel in category.channels:
-                        if channel.id == self.priority_channel_id:
-                            continue  # Déjà ajouté
-                            
-                        # Ajouter les canaux textuels
-                        if isinstance(channel, discord.TextChannel):
-                            channels_to_check.append(channel)
-                            
-                            # Récupérer les threads actifs
-                            try:
-                                active_threads = await channel.active_threads()
-                                for thread in active_threads:
-                                    if thread.id not in thread_ids_checked and thread.id != self.priority_channel_id:
-                                        channels_to_check.append(thread)
-                                        thread_ids_checked.add(thread.id)
-                            except Exception as e:
-                                print(f"Erreur lors de la récupération des threads actifs dans {channel.name}: {e}")
-                            
-                            # Récupérer les threads archivés
-                            try:
-                                # Utiliser la méthode de récupération d'archives privées
-                                private_threads = await channel.archived_threads(limit=100, private=True)
-                                for thread in private_threads:
-                                    if thread.id not in thread_ids_checked and thread.id != self.priority_channel_id:
-                                        channels_to_check.append(thread)
-                                        thread_ids_checked.add(thread.id)
-                                
-                                # Utiliser la méthode de récupération d'archives publiques
-                                public_threads = await channel.archived_threads(limit=100, private=False)
-                                for thread in public_threads:
-                                    if thread.id not in thread_ids_checked and thread.id != self.priority_channel_id:
-                                        channels_to_check.append(thread)
-                                        thread_ids_checked.add(thread.id)
-                            except Exception as e:
-                                print(f"Erreur lors de la récupération des threads archivés dans {channel.name}: {e}")
-                        
-                        # Pour les forums, récupérer leurs threads
-                        elif isinstance(channel, discord.ForumChannel):
-                            # On peut seulement parcourir les posts du forum directement
-                            channels_to_check.append(channel)
-            
-            # Récupérer les fils actifs du serveur (méthode alternative)
-            try:
-                await self._update_status(status_message, "En cours", 
-                    "Récupération de tous les fils actifs du serveur...", discord.Color.blue())
-                    
-                active_threads = ctx.guild.active_threads
-                for thread in active_threads:
-                    if (thread.id not in thread_ids_checked and 
-                        thread.id != self.priority_channel_id and 
-                        (thread.parent and thread.parent.category_id in self.category_ids)):
-                        channels_to_check.append(thread)
-                        thread_ids_checked.add(thread.id)
-            except Exception as e:
-                print(f"Erreur lors de la récupération des threads actifs du serveur: {e}")
-            
-            total_channels = len(channels_to_check)
-            await self._update_status(status_message, "En cours", 
-                f"**Phase 1/2**: Analyse de {total_channels} canaux et fils dans les catégories spécifiées...", discord.Color.blue())
-            
-            # Compteurs pour les statistiques
-            channels_processed = 0
-            messages_checked = 0
-            start_time = datetime.datetime.now()
-            
-            # Parcourir tous les canaux à vérifier
-            for i, channel in enumerate(channels_to_check):
-                try:
-                    # Vérifier les permissions si possible
-                    permissions_check = True
-                    try:
-                        if hasattr(channel, "permissions_for") and not channel.permissions_for(ctx.guild.me).read_message_history:
-                            permissions_check = False
-                    except:
-                        pass
-                        
-                    if not permissions_check:
-                        continue
-                    
-                    # Déterminer le nom et le type du canal
-                    try:
-                        channel_name = getattr(channel, "name", f"Canal ID {channel.id}")
-                        channel_type = "fil" if isinstance(channel, discord.Thread) else "salon"
-                    except:
-                        channel_name = f"Canal ID {channel.id}"
-                        channel_type = "inconnu"
-                    
-                    # Calcul du pourcentage de progression
-                    channels_processed += 1
-                    percentage = (channels_processed / total_channels) * 100
-                    
-                    # Mise à jour du statut avec plus d'informations
-                    elapsed_time = (datetime.datetime.now() - start_time).total_seconds()
-                    minutes, seconds = divmod(int(elapsed_time), 60)
-                    
-                    progress_info = (
-                        f"**Phase 1/2**: Analyse du {channel_type} **{channel_name}** ({i+1}/{total_channels})\n"
-                        f"Progression: {percentage:.1f}% | Temps écoulé: {minutes}m {seconds}s\n"
-                        f"Messages vérifiés: {messages_checked}"
-                    )
-                    
-                    await self._update_status(status_message, "En cours", progress_info, discord.Color.blue())
-                    
-                    # Parcourir l'historique des messages jusqu'à la date limite
-                    try:
-                        async for message in channel.history(limit=None, after=cutoff_date):
-                            messages_checked += 1
-                            
-                            # Mise à jour périodique du compteur de messages
-                            if messages_checked % 500 == 0:
-                                elapsed_time = (datetime.datetime.now() - start_time).total_seconds()
-                                minutes, seconds = divmod(int(elapsed_time), 60)
-                                
-                                progress_info = (
-                                    f"**Phase 1/2**: Analyse du {channel_type} **{channel_name}** ({i+1}/{total_channels})\n"
-                                    f"Progression: {percentage:.1f}% | Temps écoulé: {minutes}m {seconds}s\n"
-                                    f"Messages vérifiés: {messages_checked}"
-                                )
-                                await self._update_status(status_message, "En cours", progress_info, discord.Color.blue())
-                            
-                            author_id = message.author.id
-                            # Vérifier si l'auteur a le rôle cible
-                            if author_id in [member.id for member in members_with_role]:
-                                # Stocker la date la plus récente
-                                if author_id not in last_message_dates or message.created_at > last_message_dates[author_id]:
-                                    last_message_dates[author_id] = message.created_at
-                    except AttributeError:
-                        # Certains types de canaux pourraient ne pas avoir de méthode history()
-                        continue
-                    except Exception as e:
-                        print(f"Erreur pendant la lecture de l'historique de {channel_name}: {e}")
-                        continue
-                    
-                except discord.errors.Forbidden:
-                    continue
-                except Exception as e:
-                    error_msg = f"Erreur lors de l'analyse du canal {getattr(channel, 'name', str(channel.id))}: {e}"
-                    print(error_msg)
-                    continue
-            
-            # Génération du rapport
-            await self._update_status(status_message, "Génération du rapport", 
-                                     f"**Phase 2/2**: Traitement des résultats pour {len(members_with_role)} membres...", 
-                                     discord.Color.gold())
-            
-            now = datetime.datetime.now(datetime.timezone.utc)
-            inactive_members = []
-            
-            for member in members_with_role:
-                if member.id in last_message_dates:
-                    last_date = last_message_dates[member.id]
-                    days_inactive = (now - last_date).days
-                    if max_days is None or days_inactive >= max_days:
-                        inactive_members.append((member, days_inactive, last_date))
-                else:
-                    inactive_members.append((member, None, None))
-            
-            # Trier les membres par inactivité (du plus inactif au moins inactif)
-            # Les membres sans date trouvée apparaissent en premier
-            inactive_members.sort(key=lambda x: x[1] if x[1] is not None else float('inf'), reverse=True)
-            
-            # Terminer la mise à jour périodique du statut
-            update_task.cancel()
-            
-            # Statistiques finales
-            elapsed_time = (datetime.datetime.now() - start_time).total_seconds()
-            minutes, seconds = divmod(int(elapsed_time), 60)
-            
-            stats = (
-                f"**Recherche terminée en {minutes}m {seconds}s**\n"
-                f"Canaux analysés: {channels_processed}/{total_channels}\n"
-                f"Messages vérifiés: {messages_checked}\n"
-                f"Membres avec activité trouvée: {len(last_message_dates)}/{len(members_with_role)}\n"
-                f"Membres inactifs listés: {len(inactive_members)}"
+
+            await self._update_status(
+                status_message,
+                "En cours",
+                f"Préparation de l'analyse pour {len(members_with_role)} membres avec le rôle {role.name}...",
+                discord.Color.blue()
             )
-            
-            await self._update_status(status_message, "Terminé", stats, discord.Color.green())
-            
-            # Envoyer le rapport avec un format plus élégant
-            if inactive_members:
-                # Créer des embeds pour chaque membre inactif
-                for i, (member, days, last_date) in enumerate(inactive_members):
-                    embed = discord.Embed(
-                        title=f"Membre inactif #{i+1}/{len(inactive_members)}",
-                        color=discord.Color.orange()
-                    )
-                    
-                    # Ajouter l'avatar du membre si disponible
-                    if member.avatar:
-                        embed.set_thumbnail(url=member.avatar.url)
-                    
-                    # Ajouter les informations du membre
-                    embed.add_field(name="Membre", value=f"{member.mention} ({member.display_name})", inline=False)
-                    embed.add_field(name="ID", value=member.id, inline=True)
-                    
-                    # Ajouter les informations d'inactivité
-                    if days is not None:
-                        embed.add_field(name="Inactivité", value=f"{days} jours", inline=True)
-                        last_date_str = last_date.strftime("%d/%m/%Y %H:%M")
-                        embed.add_field(name="Dernier message", value=last_date_str, inline=True)
-                    else:
-                        embed.add_field(name="Inactivité", value=f"Aucun message trouvé depuis au moins {limit_days} jours", inline=False)
-                    
-                    # Ajouter la date d'arrivée sur le serveur si disponible
-                    if member.joined_at:
-                        join_date_str = member.joined_at.strftime("%d/%m/%Y")
-                        embed.add_field(name="A rejoint le", value=join_date_str, inline=True)
-                    
-                    await ctx.send(embed=embed)
-            else:
-                await ctx.send(f"Aucun membre inactif trouvé avec le rôle {role.name}.")
-                
+
+            cutoff_date = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=limit_days)
+
+            channels_to_check = await self._get_channels_to_check(ctx, status_message)
+
+            (last_message_dates, channels_processed, messages_checked,
+             total_channels, start_time) = await self._analyze_messages(
+                ctx, channels_to_check, members_with_role, status_message, cutoff_date
+            )
+
+            await self._generate_report(
+                ctx, role, members_with_role, last_message_dates, status_message,
+                start_time, max_days, limit_days, channels_processed, total_channels, messages_checked
+            )
+
         except Exception as e:
             await self._update_status(status_message, "Erreur", f"Une erreur s'est produite: {str(e)}", discord.Color.red())
             raise e
         finally:
-            # S'assurer que la tâche d'update est annulée
             if not update_task.done():
                 update_task.cancel()
-    
+
+    async def _get_channels_to_check(self, ctx, status_message):
+        channels_to_check = []
+        thread_ids_checked = set()
+
+        priority_channel = ctx.guild.get_channel(self.priority_channel_id)
+        if priority_channel:
+            channels_to_check.append(priority_channel)
+
+        for category_id in self.category_ids:
+            category = ctx.guild.get_channel(category_id)
+            if category and isinstance(category, discord.CategoryChannel):
+                await self._update_status(status_message, "En cours", f"Listage des canaux de la catégorie {category.name}...", discord.Color.blue())
+
+                for channel in category.channels:
+                    if channel.id == self.priority_channel_id:
+                        continue
+
+                    if isinstance(channel, discord.TextChannel):
+                        channels_to_check.append(channel)
+
+                        try:
+                            active_threads = await channel.active_threads()
+                            for thread in active_threads:
+                                if thread.id not in thread_ids_checked and thread.id != self.priority_channel_id:
+                                    channels_to_check.append(thread)
+                                    thread_ids_checked.add(thread.id)
+                        except Exception as e:
+                            logger.error(f"Erreur lors de la récupération des threads actifs dans {channel.name}: {e}")
+
+                        try:
+                            private_threads = await channel.archived_threads(limit=100, private=True)
+                            for thread in private_threads:
+                                if thread.id not in thread_ids_checked and thread.id != self.priority_channel_id:
+                                    channels_to_check.append(thread)
+                                    thread_ids_checked.add(thread.id)
+
+                            public_threads = await channel.archived_threads(limit=100, private=False)
+                            for thread in public_threads:
+                                if thread.id not in thread_ids_checked and thread.id != self.priority_channel_id:
+                                    channels_to_check.append(thread)
+                                    thread_ids_checked.add(thread.id)
+                        except Exception as e:
+                            logger.error(f"Erreur lors de la récupération des threads archivés dans {channel.name}: {e}")
+
+                    elif isinstance(channel, discord.ForumChannel):
+                        channels_to_check.append(channel)
+
+        try:
+            await self._update_status(status_message, "En cours", "Récupération de tous les fils actifs du serveur...", discord.Color.blue())
+
+            active_threads = ctx.guild.active_threads
+            for thread in active_threads:
+                if (thread.id not in thread_ids_checked and
+                    thread.id != self.priority_channel_id and
+                    (thread.parent and thread.parent.category_id in self.category_ids)):
+                    channels_to_check.append(thread)
+                    thread_ids_checked.add(thread.id)
+        except Exception as e:
+            logger.error(f"Erreur lors de la récupération des threads actifs du serveur: {e}")
+
+        return channels_to_check
+
+    async def _analyze_messages(self, ctx, channels_to_check, members_with_role, status_message, cutoff_date):
+        last_message_dates = {}
+        channels_processed = 0
+        messages_checked = 0
+        total_channels = len(channels_to_check)
+        start_time = datetime.datetime.now()
+        member_ids = [m.id for m in members_with_role]
+
+        await self._update_status(
+            status_message,
+            "En cours",
+            f"**Phase 1/2**: Analyse de {total_channels} canaux et fils dans les catégories spécifiées...",
+            discord.Color.blue()
+        )
+
+        for i, channel in enumerate(channels_to_check):
+            try:
+                permissions_check = True
+                try:
+                    if hasattr(channel, "permissions_for") and not channel.permissions_for(ctx.guild.me).read_message_history:
+                        permissions_check = False
+                except Exception:
+                    pass
+
+                if not permissions_check:
+                    continue
+
+                try:
+                    channel_name = getattr(channel, "name", f"Canal ID {channel.id}")
+                    channel_type = "fil" if isinstance(channel, discord.Thread) else "salon"
+                except Exception:
+                    channel_name = f"Canal ID {channel.id}"
+                    channel_type = "inconnu"
+
+                channels_processed += 1
+                percentage = (channels_processed / total_channels) * 100
+
+                elapsed_time = (datetime.datetime.now() - start_time).total_seconds()
+                minutes, seconds = divmod(int(elapsed_time), 60)
+
+                progress_info = (
+                    f"**Phase 1/2**: Analyse du {channel_type} **{channel_name}** ({i+1}/{total_channels})\n"
+                    f"Progression: {percentage:.1f}% | Temps écoulé: {minutes}m {seconds}s\n"
+                    f"Messages vérifiés: {messages_checked}"
+                )
+
+                await self._update_status(status_message, "En cours", progress_info, discord.Color.blue())
+
+                try:
+                    async for message in channel.history(limit=None, after=cutoff_date):
+                        messages_checked += 1
+
+                        if messages_checked % 500 == 0:
+                            elapsed_time = (datetime.datetime.now() - start_time).total_seconds()
+                            minutes, seconds = divmod(int(elapsed_time), 60)
+                            progress_info = (
+                                f"**Phase 1/2**: Analyse du {channel_type} **{channel_name}** ({i+1}/{total_channels})\n"
+                                f"Progression: {percentage:.1f}% | Temps écoulé: {minutes}m {seconds}s\n"
+                                f"Messages vérifiés: {messages_checked}"
+                            )
+                            await self._update_status(status_message, "En cours", progress_info, discord.Color.blue())
+
+                        author_id = message.author.id
+                        if author_id in member_ids:
+                            if author_id not in last_message_dates or message.created_at > last_message_dates[author_id]:
+                                last_message_dates[author_id] = message.created_at
+                except AttributeError:
+                    continue
+                except Exception as e:
+                    logger.error(f"Erreur pendant la lecture de l'historique de {channel_name}: {e}")
+                    continue
+
+            except discord.errors.Forbidden:
+                continue
+            except Exception as e:
+                logger.error(f"Erreur lors de l'analyse du canal {getattr(channel, 'name', str(channel.id))}: {e}")
+                continue
+
+        return last_message_dates, channels_processed, messages_checked, total_channels, start_time
+
+    async def _generate_report(self, ctx, role, members_with_role, last_message_dates, status_message, start_time, max_days, limit_days, channels_processed, total_channels, messages_checked):
+        await self._update_status(
+            status_message,
+            "Génération du rapport",
+            f"**Phase 2/2**: Traitement des résultats pour {len(members_with_role)} membres...",
+            discord.Color.gold()
+        )
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        inactive_members = []
+
+        for member in members_with_role:
+            if member.id in last_message_dates:
+                last_date = last_message_dates[member.id]
+                days_inactive = (now - last_date).days
+                if max_days is None or days_inactive >= max_days:
+                    inactive_members.append((member, days_inactive, last_date))
+            else:
+                inactive_members.append((member, None, None))
+
+        inactive_members.sort(key=lambda x: x[1] if x[1] is not None else float('inf'), reverse=True)
+
+        elapsed_time = (datetime.datetime.now() - start_time).total_seconds()
+        minutes, seconds = divmod(int(elapsed_time), 60)
+
+        stats = (
+            f"**Recherche terminée en {minutes}m {seconds}s**\n"
+            f"Canaux analysés: {channels_processed}/{total_channels}\n"
+            f"Messages vérifiés: {messages_checked}\n"
+            f"Membres avec activité trouvée: {len(last_message_dates)}/{len(members_with_role)}\n"
+            f"Membres inactifs listés: {len(inactive_members)}"
+        )
+
+        await self._update_status(status_message, "Terminé", stats, discord.Color.green())
+
+        if inactive_members:
+            for i, (member, days, last_date) in enumerate(inactive_members):
+                embed = discord.Embed(
+                    title=f"Membre inactif #{i+1}/{len(inactive_members)}",
+                    color=discord.Color.orange(),
+                )
+
+                if member.avatar:
+                    embed.set_thumbnail(url=member.avatar.url)
+
+                embed.add_field(name="Membre", value=f"{member.mention} ({member.display_name})", inline=False)
+                embed.add_field(name="ID", value=member.id, inline=True)
+
+                if days is not None:
+                    embed.add_field(name="Inactivité", value=f"{days} jours", inline=True)
+                    last_date_str = last_date.strftime("%d/%m/%Y %H:%M")
+                    embed.add_field(name="Dernier message", value=last_date_str, inline=True)
+                else:
+                    embed.add_field(name="Inactivité", value=f"Aucun message trouvé depuis au moins {limit_days} jours", inline=False)
+
+                if member.joined_at:
+                    join_date_str = member.joined_at.strftime("%d/%m/%Y")
+                    embed.add_field(name="A rejoint le", value=join_date_str, inline=True)
+
+                await ctx.send(embed=embed)
+        else:
+            await ctx.send(f"Aucun membre inactif trouvé avec le rôle {role.name}.")
+
     async def _update_status(self, message, title, description, color):
         """Met à jour le message de statut avec un nouvel embed."""
         embed = discord.Embed(
@@ -313,7 +299,7 @@ class InactiveUserTracker(commands.Cog):
             timestamp=datetime.datetime.now()
         )
         await message.edit(embed=embed)
-    
+
     async def _update_status_periodically(self, message):
         """Met à jour périodiquement le message de statut pour montrer que le bot est toujours actif."""
         dots = 0
@@ -322,7 +308,6 @@ class InactiveUserTracker(commands.Cog):
                 dots = (dots % 3) + 1
                 embed = message.embeds[0]
                 if not embed.description.endswith("..."):
-                    # Ne modifie pas si la description a changé entre-temps
                     pass
                 else:
                     new_desc = embed.description.rstrip(".") + "." * dots
@@ -330,10 +315,9 @@ class InactiveUserTracker(commands.Cog):
                     await message.edit(embed=embed)
                 await asyncio.sleep(2)
         except asyncio.CancelledError:
-            # Tâche annulée normalement
             pass
         except Exception as e:
-            print(f"Erreur dans la mise à jour périodique: {e}")
+            logger.error(f"Erreur dans la mise à jour périodique: {e}")
 
 async def setup(bot):
     await bot.add_cog(InactiveUserTracker(bot))

--- a/tests/test_inactive_user_tracker.py
+++ b/tests/test_inactive_user_tracker.py
@@ -1,0 +1,130 @@
+import datetime
+import pytest
+from unittest.mock import AsyncMock
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from cogs import InactiveUserTracker as iut
+
+# Patch discord Color for tests
+class DummyColor:
+    blue = staticmethod(lambda: None)
+    gold = staticmethod(lambda: None)
+    green = staticmethod(lambda: None)
+    orange = staticmethod(lambda: None)
+    red = staticmethod(lambda: None)
+
+iut.discord.Color = DummyColor
+
+class DummyThread:
+    def __init__(self, id, name, parent=None):
+        self.id = id
+        self.name = name
+        self.parent = parent
+
+iut.discord.Thread = DummyThread
+
+class DummyTextChannel:
+    def __init__(self, id, name, threads=None):
+        self.id = id
+        self.name = name
+        self._threads = threads or []
+    async def active_threads(self):
+        return self._threads
+    async def archived_threads(self, limit=100, private=True):
+        return []
+
+class DummyCategory:
+    def __init__(self, id, name, channels):
+        self.id = id
+        self.name = name
+        self.channels = channels
+
+iut.discord.TextChannel = DummyTextChannel
+
+iut.discord.CategoryChannel = DummyCategory
+
+iut.discord.ForumChannel = DummyTextChannel
+
+iut.discord.errors = type('errors', (), {'Forbidden': Exception})
+
+class DummyGuild:
+    def __init__(self, channels, active_threads=None):
+        self._channels = {c.id: c for c in channels}
+        self.active_threads = active_threads or []
+        self.me = object()
+    def get_channel(self, cid):
+        return self._channels.get(cid)
+
+class DummyCtx:
+    def __init__(self, guild):
+        self.guild = guild
+
+@pytest.mark.asyncio
+async def test_get_channels_to_check():
+    tracker = iut.InactiveUserTracker(bot=None)
+    tracker._update_status = AsyncMock()
+    thread = DummyThread(3, 'thread')
+    text_channel = DummyTextChannel(2, 'text', threads=[thread])
+    priority = DummyTextChannel(tracker.priority_channel_id, 'priority')
+    category = DummyCategory(tracker.category_ids[0], 'cat', [text_channel])
+    guild = DummyGuild([priority, category])
+    ctx = DummyCtx(guild)
+    channels = await tracker._get_channels_to_check(ctx, None)
+    assert priority in channels
+    assert text_channel in channels
+    assert thread in channels
+
+class DummyMessage:
+    def __init__(self, author_id, created_at):
+        self.author = type('A', (), {'id': author_id})
+        self.created_at = created_at
+
+class HistoryChannel(DummyTextChannel):
+    def __init__(self, id, name, messages):
+        super().__init__(id, name)
+        self.messages = messages
+    def permissions_for(self, me):
+        return type('P', (), {'read_message_history': True})
+    async def history(self, limit=None, after=None):
+        for m in self.messages:
+            if after is None or m.created_at > after:
+                yield m
+
+@pytest.mark.asyncio
+async def test_analyze_messages():
+    tracker = iut.InactiveUserTracker(bot=None)
+    tracker._update_status = AsyncMock()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    msg = DummyMessage(1, now - datetime.timedelta(days=1))
+    channel = HistoryChannel(10, 'chan', [msg])
+    ctx = DummyCtx(type('G', (), {'me': object()}))
+    result = await tracker._analyze_messages(ctx, [channel], [type('M', (), {'id':1})], None, now - datetime.timedelta(days=30))
+    last_dates, channels_processed, messages_checked, total_channels, start_time = result
+    assert last_dates[1] == msg.created_at
+    assert channels_processed == 1
+    assert messages_checked == 1
+    assert total_channels == 1
+
+class DummyMember:
+    def __init__(self, id, mention, display_name, avatar=None, joined_at=None):
+        self.id = id
+        self.mention = mention
+        self.display_name = display_name
+        self.avatar = avatar
+        self.joined_at = joined_at
+
+@pytest.mark.asyncio
+async def test_generate_report():
+    tracker = iut.InactiveUserTracker(bot=None)
+    tracker._update_status = AsyncMock()
+    iut.discord.Embed = type('Embed', (), {'__init__': lambda self, **kwargs: None, 'set_thumbnail': lambda self, url: None, 'add_field': lambda self, name, value, inline=True: None})
+    ctx = type('C', (), {'send': AsyncMock()})
+    role = type('R', (), {'name': 'role'})
+    tz_now = datetime.datetime.now(datetime.timezone.utc)
+    start_time = datetime.datetime.now() - datetime.timedelta(minutes=1)
+    member1 = DummyMember(1, '@1', 'm1')
+    member2 = DummyMember(2, '@2', 'm2')
+    last_dates = {1: tz_now - datetime.timedelta(days=5)}
+    await tracker._generate_report(ctx, role, [member1, member2], last_dates, None, start_time, 3, 30, 0, 0, 0)
+    assert ctx.send.await_count == 2


### PR DESCRIPTION
## Summary
- split inactive search into channel gathering, message analysis, and report generation helpers
- replace direct prints with logger.error calls
- add unit tests for new helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689519089b6883238b7ed5358e16d3cd