### PR TITLE
feat: add exchange board for card trading

### DIFF
--- a/cogs/Cards.py
+++ b/cogs/Cards.py
@@ -1850,6 +1850,37 @@ class Cards(commands.Cog):
             logger.error(f"[ADMIN_GALLERY] Erreur: {e}")
             await ctx.send("❌ Une erreur est survenue lors de l'affichage de la galerie.")
 
+    @commands.group(name="board", invoke_without_command=True)
+    async def board_group(self, ctx: commands.Context):
+        """Commandes du tableau d'échanges."""
+        await ctx.send("Utilisation: !board list|deposit|take")
+
+    @board_group.command(name="list")
+    async def board_list(self, ctx: commands.Context):
+        offers = self.trading_manager.list_board_offers()
+        if not offers:
+            await ctx.send("Le tableau est vide.")
+            return
+        lines = [
+            f"{o['id']}: {o['name'].removesuffix('.png')} ({o['cat']}) - {o['owner']}"
+            for o in offers
+        ]
+        await ctx.send("\n".join(lines))
+
+    @board_group.command(name="deposit")
+    async def board_deposit(self, ctx: commands.Context, cat: str, *, name: str):
+        if self.trading_manager.deposit_to_board(ctx.author.id, cat, name):
+            await ctx.send("Carte déposée sur le tableau.")
+        else:
+            await ctx.send("Impossible de déposer la carte.")
+
+    @board_group.command(name="take")
+    async def board_take(self, ctx: commands.Context, board_id: int, cat: str, *, name: str):
+        if self.trading_manager.take_from_board(ctx.author.id, board_id, cat, name):
+            await ctx.send("Échange réalisé avec succès.")
+        else:
+            await ctx.send("Échange impossible.")
+
     @commands.command(name="give_bonus")
     @commands.has_permissions(administrator=True)
     async def give_bonus(self, ctx: commands.Context, member: discord.Member, count: int = 1, *, source: str):

--- a/cogs/cards/README.md
+++ b/cogs/cards/README.md
@@ -101,6 +101,7 @@ Toutes les fonctionnalités originales sont préservées :
 - ✅ Gestion des cartes Full
 - ✅ Système de cache optimisé
 - ✅ Sécurité et validation des données
+- ✅ Tableau d'échanges avec commandes `!board`
 
 ## 🧪 Tests
 

--- a/cogs/cards/trading.py
+++ b/cogs/cards/trading.py
@@ -19,6 +19,153 @@ class TradingManager:
     def __init__(self, storage: CardsStorage, vault_manager: VaultManager):
         self.storage = storage
         self.vault_manager = vault_manager
+
+    # ------------------------------------------------------------------
+    # Tableau d'échanges
+    # ------------------------------------------------------------------
+
+    def list_board_offers(self) -> List[dict]:
+        """Retourne toutes les offres présentes sur le tableau d'échanges."""
+        return self.storage.get_exchange_entries()
+
+    def deposit_to_board(self, user_id: int, cat: str, name: str) -> bool:
+        """Dépose une carte sur le tableau d'échanges."""
+        try:
+            if not validate_card_data(cat, name, user_id):
+                return False
+
+            if not self._user_has_card(user_id, cat, name):
+                logging.error(f"[BOARD] Utilisateur {user_id} ne possède pas la carte ({cat}, {name})")
+                return False
+
+            timestamp = datetime.now(pytz.timezone("Europe/Paris")).isoformat()
+
+            with self.storage._cards_lock, self.storage._board_lock:
+                if not self._remove_card_from_user(user_id, cat, name):
+                    return False
+                entry_id = self.storage.create_exchange_entry(user_id, cat, name, timestamp)
+                if entry_id is None:
+                    self._add_card_to_user(user_id, cat, name)
+                    return False
+
+            if self.storage.logging_manager:
+                self.storage.logging_manager.log_card_remove(
+                    user_id=user_id,
+                    user_name=f"User_{user_id}",
+                    category=cat,
+                    name=name,
+                    details="Déposé sur le tableau d'échanges",
+                    source="board_deposit"
+                )
+
+            return True
+
+        except Exception as e:
+            logging.error(f"[BOARD] Erreur lors du dépôt: {e}")
+            return False
+
+    def take_from_board(self, user_id: int, board_id: int,
+                        offered_cat: str, offered_name: str) -> bool:
+        """Réalise un échange en prenant une carte du tableau."""
+        try:
+            if not validate_card_data(offered_cat, offered_name, user_id):
+                return False
+
+            with self.storage._cards_lock, self.storage._board_lock:
+                entry = self.storage.get_exchange_entry(board_id)
+                if not entry:
+                    return False
+
+                owner_id = int(entry["owner"])
+                board_cat = entry["cat"]
+                board_name = entry["name"]
+
+                # Valider la carte proposée
+                if offered_cat != board_cat:
+                    logging.error(f"[BOARD] Catégorie proposée {offered_cat} différente de {board_cat}")
+                    return False
+
+                if not self._user_has_card(user_id, offered_cat, offered_name):
+                    logging.error(f"[BOARD] Utilisateur {user_id} ne possède pas la carte proposée")
+                    return False
+
+                # Retirer la carte offerte du preneur
+                if not self._remove_card_from_user(user_id, offered_cat, offered_name):
+                    return False
+
+                # Ajouter la carte offerte au propriétaire
+                if not self._add_card_to_user(owner_id, offered_cat, offered_name):
+                    self._add_card_to_user(user_id, offered_cat, offered_name)
+                    return False
+
+                # Donner la carte du tableau au preneur
+                if not self._add_card_to_user(user_id, board_cat, board_name):
+                    self._remove_card_from_user(owner_id, offered_cat, offered_name)
+                    self._add_card_to_user(user_id, offered_cat, offered_name)
+                    return False
+
+                # Supprimer l'entrée du tableau
+                if not self.storage.delete_exchange_entry(board_id):
+                    # Rollback complet
+                    self._remove_card_from_user(user_id, board_cat, board_name)
+                    self._remove_card_from_user(owner_id, offered_cat, offered_name)
+                    self._add_card_to_user(user_id, offered_cat, offered_name)
+                    return False
+
+            if self.storage.logging_manager:
+                self.storage.logging_manager.log_trade_direct(
+                    offerer_id=user_id,
+                    offerer_name=f"User_{user_id}",
+                    target_id=owner_id,
+                    target_name=f"User_{owner_id}",
+                    offer_card=(offered_cat, offered_name),
+                    return_card=(board_cat, board_name),
+                    source="board_exchange"
+                )
+
+            if hasattr(self.storage, '_cog_ref'):
+                self.storage._cog_ref._mark_user_for_upgrade_check(user_id)
+                self.storage._cog_ref._mark_user_for_upgrade_check(owner_id)
+
+            return True
+
+        except Exception as e:
+            logging.error(f"[BOARD] Erreur lors de l'échange: {e}")
+            return False
+
+    def cleanup_board(self, max_age_hours: int = 24) -> None:
+        """Retire les offres expirées et restitue les cartes."""
+        try:
+            now = datetime.now(pytz.timezone("Europe/Paris"))
+            entries = self.list_board_offers()
+            for entry in entries:
+                try:
+                    ts = datetime.fromisoformat(entry["timestamp"])
+                except Exception:
+                    ts = None
+
+                if ts and now - ts < timedelta(hours=max_age_hours):
+                    continue
+
+                owner_id = int(entry["owner"])
+                cat = entry["cat"]
+                name = entry["name"]
+                entry_id = int(entry["id"])
+
+                with self.storage._cards_lock, self.storage._board_lock:
+                    if self.storage.delete_exchange_entry(entry_id):
+                        self._add_card_to_user(owner_id, cat, name)
+                        if self.storage.logging_manager:
+                            self.storage.logging_manager.log_card_add(
+                                user_id=owner_id,
+                                user_name=f"User_{owner_id}",
+                                category=cat,
+                                name=name,
+                                details="Retour après expiration du tableau",
+                                source="board_cleanup"
+                            )
+        except Exception as e:
+            logging.error(f"[BOARD] Erreur lors du nettoyage du tableau: {e}")
     
     def safe_exchange(self, offerer_id: int, target_id: int, 
                      offer_cat: str, offer_name: str, 

--- a/cogs/cards/views/__init__.py
+++ b/cogs/cards/views/__init__.py
@@ -7,10 +7,11 @@ Contient toutes les interfaces utilisateur (Views, Modals, Buttons).
 from .menu_views import CardsMenuView, SacrificialDrawConfirmationView
 from .trade_views import (
     TradeMenuView, TradeConfirmationView, InitiatorFinalConfirmationView,
-    WithdrawVaultConfirmationView
+    WithdrawVaultConfirmationView, ExchangeBoardView
 )
 from .gallery_views import GalleryView, AdminGalleryView
 from .modal_views import (
     DepositCardModal, InitiateTradeModal,
-    TradeOfferCardModal, TradeResponseModal
+    TradeOfferCardModal, TradeResponseModal,
+    BoardDepositModal, OfferCardModal
 )

--- a/cogs/cards/views/menu_views.py
+++ b/cogs/cards/views/menu_views.py
@@ -412,22 +412,20 @@ class CardsMenuView(discord.ui.View):
             return
         
         await interaction.response.defer(ephemeral=True)
-        
+
         try:
-            # Importer ici pour éviter les imports circulaires
-            from .trade_views import TradeMenuView
-            
-            # Créer la vue de trading
-            trade_view = TradeMenuView(self.cog, self.user)
-            
+            from .trade_views import ExchangeBoardView
+
+            board_view = ExchangeBoardView(self.cog, self.user)
+
             embed = discord.Embed(
-                title="🔄 Menu des échanges",
-                description="Choisissez une action d'échange :",
+                title="🔄 Tableau d'échanges",
+                description="Déposez une carte ou échangez-en une avec un autre joueur.",
                 color=0x3498db
             )
-            
-            await interaction.followup.send(embed=embed, view=trade_view, ephemeral=True)
-            
+
+            await interaction.followup.send(embed=embed, view=board_view, ephemeral=True)
+
         except Exception as e:
             logging.error(f"[MENU] Erreur lors de l'affichage du menu d'échange: {e}")
             await interaction.followup.send(

--- a/tests/test_trading_board.py
+++ b/tests/test_trading_board.py
@@ -1,0 +1,120 @@
+import threading
+import pytest
+
+from cogs.cards.trading import TradingManager
+
+
+class FakeLoggingManager:
+    def log_card_remove(self, **kwargs):
+        return True
+
+    def log_trade_direct(self, **kwargs):
+        return True
+
+    def log_card_add(self, **kwargs):
+        return True
+
+
+class FakeStorage:
+    def __init__(self):
+        self._cards_lock = threading.RLock()
+        self._board_lock = threading.RLock()
+        self.entries = []
+        self.logging_manager = FakeLoggingManager()
+
+    # CRUD minimal
+    def create_exchange_entry(self, owner, cat, name, ts):
+        entry_id = len(self.entries) + 1
+        self.entries.append({
+            "id": entry_id,
+            "owner": owner,
+            "cat": cat,
+            "name": name,
+            "timestamp": ts,
+        })
+        return entry_id
+
+    def get_exchange_entries(self):
+        return list(self.entries)
+
+    def get_exchange_entry(self, entry_id):
+        for e in self.entries:
+            if e["id"] == entry_id:
+                return e
+        return None
+
+    def delete_exchange_entry(self, entry_id):
+        for i, e in enumerate(self.entries):
+            if e["id"] == entry_id:
+                self.entries.pop(i)
+                return True
+        return False
+
+
+@pytest.fixture()
+def trading_manager():
+    storage = FakeStorage()
+    tm = TradingManager(storage, vault_manager=None)
+
+    inventories = {}
+
+    def has_card(uid, cat, name):
+        return inventories.get(uid, {}).get((cat, name), 0) > 0
+
+    def add_card(uid, cat, name):
+        inventories.setdefault(uid, {})[(cat, name)] = inventories.get(uid, {}).get((cat, name), 0) + 1
+        return True
+
+    def remove_card(uid, cat, name):
+        if not has_card(uid, cat, name):
+            return False
+        inventories[uid][(cat, name)] -= 1
+        if inventories[uid][(cat, name)] == 0:
+            del inventories[uid][(cat, name)]
+        return True
+
+    tm._user_has_card = has_card
+    tm._add_card_to_user = add_card
+    tm._remove_card_from_user = remove_card
+
+    return tm, inventories, storage
+
+
+def test_deposit_to_board(trading_manager):
+    tm, inv, storage = trading_manager
+    inv[1] = {("Cat", "Card"): 1}
+    assert tm.deposit_to_board(1, "Cat", "Card")
+    assert storage.entries[0]["owner"] == 1
+    assert not tm._user_has_card(1, "Cat", "Card")
+
+
+def test_take_from_board(trading_manager):
+    tm, inv, storage = trading_manager
+    inv[1] = {("Cat", "Card"): 1}
+    tm.deposit_to_board(1, "Cat", "Card")
+    inv[2] = {("Cat", "Offer"): 1}
+    assert tm.take_from_board(2, 1, "Cat", "Offer")
+    assert tm._user_has_card(2, "Cat", "Card")
+    assert tm._user_has_card(1, "Cat", "Offer")
+    assert storage.get_exchange_entries() == []
+
+
+def test_concurrent_take(trading_manager):
+    tm, inv, storage = trading_manager
+    inv[1] = {("Cat", "Card"): 1}
+    tm.deposit_to_board(1, "Cat", "Card")
+    inv[2] = {("Cat", "OfferA"): 1}
+    inv[3] = {("Cat", "OfferB"): 1}
+
+    results = []
+
+    def attempt(uid, name):
+        res = tm.take_from_board(uid, 1, "Cat", name)
+        results.append(res)
+
+    t1 = threading.Thread(target=attempt, args=(2, "OfferA"))
+    t2 = threading.Thread(target=attempt, args=(3, "OfferB"))
+    t1.start(); t2.start(); t1.join(); t2.join()
+
+    assert sum(1 for r in results if r) == 1
+    assert storage.get_exchange_entries() == []


### PR DESCRIPTION
## Summary
- initialize `Tableau Echanges` sheet with CRUD helpers and locking
- support depositing cards to the exchange board and trading via new view/commands
- add unit tests for board deposits, exchanges and concurrent access

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689595a0bd548323aabd2b43b764488b