### PR TITLE
Intégration conversion Full après échanges

### DIFF
--- a/cogs/Cards.py
+++ b/cogs/Cards.py
@@ -1878,6 +1878,16 @@ class Cards(commands.Cog):
     async def board_take(self, ctx: commands.Context, board_id: int, cat: str, *, name: str):
         if self.trading_manager.take_from_board(ctx.author.id, board_id, cat, name):
             await ctx.send("Échange réalisé avec succès.")
+            class FakeInteraction:
+                def __init__(self, ctx):
+                    self.channel = ctx.channel
+                    self.guild = ctx.guild
+                    self.user = ctx.author
+                    self.channel_id = ctx.channel.id
+            try:
+                await self.process_all_pending_upgrade_checks(FakeInteraction(ctx), 1361993326215172218)
+            except Exception as e:
+                logger.error(f"[BOARD] Erreur lors de la vérification des conversions après échange: {e}")
         else:
             await ctx.send("Échange impossible.")
 

--- a/cogs/cards/views/trade_views.py
+++ b/cogs/cards/views/trade_views.py
@@ -708,6 +708,10 @@ class BoardTradeRequestView(discord.ui.View):
         if success:
             await interaction.followup.send("✅ Échange réalisé avec succès.", ephemeral=True)
             await self.notify_buyer("✅ Votre offre a été acceptée !")
+            try:
+                await self.cog.process_all_pending_upgrade_checks(interaction, 1361993326215172218)
+            except Exception as e:
+                logging.error(f"[BOARD_TRADE] Erreur lors de la vérification des conversions: {e}")
         else:
             await interaction.followup.send("❌ Échange impossible.", ephemeral=True)
             await self.notify_buyer("❌ Votre offre a échoué.")


### PR DESCRIPTION
## Summary
- lance la vérification d'upgrade après acceptation d'un échange via le tableau
- déclenche la même vérification pour la commande `board take`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68972777b7508323904564e88d1b3ed0