### PR TITLE
Start health monitoring after bot is ready

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,11 +140,11 @@ def main():
         member_cache_flags=discord.MemberCacheFlags.from_intents(intents)  # Cache adapté aux intents
     )
     bot.start_http_server_thread()
-    bot.start_health_check_thread()
     bot.start_self_ping_thread()
 
     async def on_ready():
         bot.ready_called = True
+        bot.start_health_check_thread()
         logger.info(f'🤖 Connecté en tant que {bot.user.name}')
         logger.info(f'🆔 ID du bot : {bot.user.id}')
         logger.info(f'🏓 Latence actuelle : {bot.latency:.2f}s')


### PR DESCRIPTION
## Summary
- Launch health check thread when bot signals readiness
- Remove pre-run health thread start to ensure monitoring begins post-startup

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689884a5662083238facbdf6be51b7ff