### PR TITLE
Affichage des pseudos dans les offres du tableau d'échanges

### DIFF
--- a/cogs/Cards.py
+++ b/cogs/Cards.py
@@ -1861,10 +1861,26 @@ class Cards(commands.Cog):
         if not offers:
             await ctx.send("Le tableau est vide.")
             return
-        lines = [
-            f"{o['id']}: {o['name'].removesuffix('.png')} ({o['cat']}) - {o['owner']}"
-            for o in offers
-        ]
+
+        lines = []
+        for o in offers:
+            owner_id = int(o["owner"])
+            member = ctx.guild.get_member(owner_id) if ctx.guild else None
+            if member:
+                owner_name = member.display_name
+            else:
+                user_obj = self.bot.get_user(owner_id)
+                if not user_obj:
+                    try:
+                        user_obj = await self.bot.fetch_user(owner_id)
+                    except Exception:
+                        user_obj = None
+                owner_name = user_obj.display_name if user_obj else str(owner_id)
+
+            lines.append(
+                f"{o['id']}: {o['name'].removesuffix('.png')} ({o['cat']}) - {owner_name}"
+            )
+
         await ctx.send("\n".join(lines))
 
     @board_group.command(name="deposit")

--- a/cogs/cards/views/menu_views.py
+++ b/cogs/cards/views/menu_views.py
@@ -416,7 +416,7 @@ class CardsMenuView(discord.ui.View):
         try:
             from .trade_views import ExchangeBoardView
 
-            board_view = ExchangeBoardView(self.cog, self.user, interaction.guild)
+            board_view = await ExchangeBoardView.create(self.cog, self.user, interaction.guild)
 
             embed = discord.Embed(
                 title="🔄 Tableau d'échanges",


### PR DESCRIPTION
## Summary
- Récupère le pseudonyme du propriétaire pour chaque offre du tableau d'échanges, même si l'utilisateur n'est pas en cache
- Utilise une méthode factory asynchrone pour construire la vue du tableau
- Met à jour les tests du tableau d'échanges pour couvrir ces cas

## Testing
- `pip install pytest-asyncio -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ac865e4c83238576292f93b4a20d