### PR TITLE
Allow cross-category exchange trades

### DIFF
--- a/cogs/cards/trading.py
+++ b/cogs/cards/trading.py
@@ -87,9 +87,6 @@ class TradingManager:
             for cat, name in offered_cards:
                 if not validate_card_data(cat, name, user_id):
                     return None
-                if cat != board_cat:
-                    logging.error(f"[BOARD] Catégorie proposée {cat} différente de {board_cat}")
-                    return None
                 if not self._user_has_card(user_id, cat, name):
                     logging.error(f"[BOARD] Utilisateur {user_id} ne possède pas la carte proposée {name}")
                     return None
@@ -115,9 +112,6 @@ class TradingManager:
 
                 for cat, name in offered_cards:
                     if not validate_card_data(cat, name, user_id):
-                        return False
-                    if cat != board_cat:
-                        logging.error(f"[BOARD] Catégorie proposée {cat} différente de {board_cat}")
                         return False
                     if not self._user_has_card(user_id, cat, name):
                         logging.error(f"[BOARD] Utilisateur {user_id} ne possède pas la carte proposée {name}")

--- a/tests/test_trading_board.py
+++ b/tests/test_trading_board.py
@@ -120,6 +120,20 @@ def test_take_from_board_multiple_cards(trading_manager):
     assert storage.get_exchange_entries() == []
 
 
+def test_take_from_board_cross_category_multiple_cards(trading_manager):
+    tm, inv, storage = trading_manager
+    inv[1] = {("Cat", "Card"): 1}
+    tm.deposit_to_board(1, "Cat", "Card")
+    inv[2] = {("Dog", "Offer1"): 1, ("Bird", "Offer2"): 1}
+    info = tm.initiate_board_trade(2, 1, [("Dog", "Offer1"), ("Bird", "Offer2")])
+    assert info is not None
+    assert tm.take_from_board(2, 1, [("Dog", "Offer1"), ("Bird", "Offer2")])
+    assert tm._user_has_card(2, "Cat", "Card")
+    assert tm._user_has_card(1, "Dog", "Offer1")
+    assert tm._user_has_card(1, "Bird", "Offer2")
+    assert storage.get_exchange_entries() == []
+
+
 def test_concurrent_take(trading_manager):
     tm, inv, storage = trading_manager
     inv[1] = {("Cat", "Card"): 1}


### PR DESCRIPTION
## Summary
- Allow trading any cards regardless of category on the exchange board
- Test trading multiple cards from different categories for a single board offer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b83488f88323bf303c2237ee9964