### PR TITLE
Refactor board trade workflow and add duplicate test

### DIFF
--- a/tests/test_trading_board.py
+++ b/tests/test_trading_board.py
@@ -106,6 +106,21 @@ def test_take_from_board(trading_manager):
     assert storage.get_exchange_entries() == []
 
 
+def test_take_from_board_owner_duplicate(trading_manager):
+    tm, inv, storage = trading_manager
+    inv[1] = {("Cat", "Card"): 2}
+    tm.deposit_to_board(1, "Cat", "Card")
+    # Le propriétaire possède toujours un doublon après le dépôt
+    assert tm._user_has_card(1, "Cat", "Card")
+    inv[2] = {("Cat", "Offer"): 1}
+    assert tm.take_from_board(2, 1, [("Cat", "Offer")])
+    assert tm._user_has_card(2, "Cat", "Card")
+    # L'autre exemplaire du propriétaire est intact
+    assert tm._user_has_card(1, "Cat", "Card")
+    assert tm._user_has_card(1, "Cat", "Offer")
+    assert storage.get_exchange_entries() == []
+
+
 def test_take_from_board_multiple_cards(trading_manager):
     tm, inv, storage = trading_manager
     inv[1] = {("Cat", "Card"): 1}


### PR DESCRIPTION
## Summary
- Delete board exchange entry before updating inventories
- Add board card to taker with full rollback on failure
- Test trading when board owner has duplicate card

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c4a9d0d88323a9191942df69a4e2