### PR TITLE
Add optional comments for exchange board entries

### DIFF
--- a/cogs/cards/trading.py
+++ b/cogs/cards/trading.py
@@ -28,7 +28,8 @@ class TradingManager:
         """Retourne toutes les offres présentes sur le tableau d'échanges."""
         return self.storage.get_exchange_entries()
 
-    def deposit_to_board(self, user_id: int, cat: str, name: str) -> bool:
+    def deposit_to_board(self, user_id: int, cat: str, name: str,
+                         comment: Optional[str] = None) -> bool:
         """Dépose une carte sur le tableau d'échanges."""
         try:
             if not validate_card_data(cat, name, user_id):
@@ -43,7 +44,9 @@ class TradingManager:
             with self.storage._cards_lock, self.storage._board_lock:
                 if not self._remove_card_from_user(user_id, cat, name):
                     return False
-                entry_id = self.storage.create_exchange_entry(user_id, cat, name, timestamp)
+                entry_id = self.storage.create_exchange_entry(
+                    user_id, cat, name, timestamp, comment
+                )
                 if entry_id is None:
                     self._add_card_to_user(user_id, cat, name)
                     return False
@@ -147,7 +150,7 @@ class TradingManager:
                         self._remove_card_from_user(owner_id, cat, name)
                     for cat, name in removed:
                         self._add_card_to_user(user_id, cat, name)
-                    self.storage.create_exchange_entry(owner_id, board_cat, board_name, timestamp)
+                    self.storage.create_exchange_entry(owner_id, board_cat, board_name, timestamp, entry.get("comment") if 'comment' in entry else None)
                     return False
 
             if self.storage.logging_manager:
@@ -188,7 +191,7 @@ class TradingManager:
 
                 if not self._add_card_to_user(user_id, cat, name):
                     # Rollback si impossible de rendre la carte
-                    self.storage.create_exchange_entry(user_id, cat, name, timestamp)
+                    self.storage.create_exchange_entry(user_id, cat, name, timestamp, entry.get("comment") if 'comment' in entry else None)
                     return False
 
             if self.storage.logging_manager:

--- a/cogs/cards/views/modal_views.py
+++ b/cogs/cards/views/modal_views.py
@@ -336,6 +336,13 @@ class BoardDepositModal(discord.ui.Modal, title="Déposer sur le tableau"):
         max_length=100,
     )
 
+    comment = discord.ui.TextInput(
+        label="Commentaire (optionnel)",
+        placeholder="Ajoutez un commentaire",
+        required=False,
+        max_length=200,
+    )
+
     def __init__(self, cog: "Cards", user: discord.User):
         super().__init__()
         self.cog = cog
@@ -355,7 +362,10 @@ class BoardDepositModal(discord.ui.Modal, title="Déposer sur le tableau"):
                 return
 
             category, name = card_match
-            success = self.cog.trading_manager.deposit_to_board(self.user.id, category, name)
+            comment = self.comment.value.strip() if self.comment.value else None
+            success = self.cog.trading_manager.deposit_to_board(
+                self.user.id, category, name, comment=comment
+            )
 
             if success:
                 display_name = name.removesuffix('.png')

--- a/cogs/cards/views/trade_views.py
+++ b/cogs/cards/views/trade_views.py
@@ -603,10 +603,13 @@ class ExchangeBoardView(discord.ui.View):
                         except Exception:
                             user_obj = None
                     owner_name = user_obj.display_name if user_obj else str(owner_id)
+                description = f"ID {o['id']} - Proposé par {owner_name}"
+                if o.get("comment"):
+                    description += f" | {o['comment']}"
                 page.append(
                     discord.SelectOption(
                         label=f"{o['name'].removesuffix('.png')} ({o['cat']})",
-                        description=f"ID {o['id']} - Proposé par {owner_name}",
+                        description=description,
                         value=str(o['id'])
                     )
                 )


### PR DESCRIPTION
## Summary
- allow exchange board entries to store an optional comment and migrate old sheets
- support comment entry and display through deposit modal, trading logic, and board view
- test comment storage and rendering in ExchangeBoardView

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990146c9f08323bd2993b2305bdc29