### PR TITLE
Handle Google Sheets reconnection in surveillance task

### DIFF
--- a/cogs/Surveillance_scene.py
+++ b/cogs/Surveillance_scene.py
@@ -218,8 +218,11 @@ class SurveillanceScene(commands.Cog):
     @tasks.loop(hours=1)
     async def update_surveillance(self):
         """Met à jour la surveillance toutes les heures."""
-        if not self.sheet:
-            return
+        if self.sheet is None:
+            self.setup_google_sheets()
+            if self.sheet is None:
+                logging.error("Impossible de se reconnecter à Google Sheets dans update_surveillance")
+                return
             
         try:
             await self.refresh_monitored_scenes()

--- a/tests/test_surveillance_scene.py
+++ b/tests/test_surveillance_scene.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from cogs import Surveillance_scene as ss
+
+
+@pytest.mark.asyncio
+async def test_update_surveillance_reconnects_and_updates():
+    scene = ss.SurveillanceScene.__new__(ss.SurveillanceScene)
+    scene.sheet = None
+
+    def reconnect():
+        scene.sheet = object()
+
+    scene.setup_google_sheets = MagicMock(side_effect=reconnect)
+    scene.refresh_monitored_scenes = AsyncMock()
+    scene.update_all_scenes = AsyncMock()
+
+    await scene.update_surveillance()
+
+    scene.setup_google_sheets.assert_called_once()
+    assert scene.refresh_monitored_scenes.await_count == 1
+    assert scene.update_all_scenes.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_update_surveillance_logs_error_when_no_sheet(caplog):
+    scene = ss.SurveillanceScene.__new__(ss.SurveillanceScene)
+    scene.sheet = None
+    scene.setup_google_sheets = MagicMock()  # no side effect, remains None
+    scene.refresh_monitored_scenes = AsyncMock()
+    scene.update_all_scenes = AsyncMock()
+
+    with caplog.at_level("ERROR"):
+        await scene.update_surveillance()
+
+    scene.setup_google_sheets.assert_called_once()
+    scene.refresh_monitored_scenes.assert_not_called()
+    scene.update_all_scenes.assert_not_called()
+    assert "Impossible de se reconnecter" in caplog.text
+


### PR DESCRIPTION
## Summary
- retry Google Sheets connection inside `update_surveillance`
- add tests ensuring reconnection and error logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b2c0480308323ba35d172e43e70fe