### PR TITLE
Improve Google Sheets reconnection in surveillance task

### DIFF
--- a/cogs/Surveillance_scene.py
+++ b/cogs/Surveillance_scene.py
@@ -219,9 +219,27 @@ class SurveillanceScene(commands.Cog):
     async def update_surveillance(self):
         """Met à jour la surveillance toutes les heures."""
         if self.sheet is None:
-            self.setup_google_sheets()
+            max_attempts = 3
+            for attempt in range(1, max_attempts + 1):
+                logging.warning(
+                    f"Feuille Google Sheets indisponible, tentative de reconnexion {attempt}/{max_attempts}"
+                )
+                self.setup_google_sheets()
+                if self.sheet is not None:
+                    logging.info(
+                        f"Reconnexion réussie à Google Sheets lors de la tentative {attempt}"
+                    )
+                    break
+                delay = 5 * attempt
+                logging.error(
+                    f"Tentative {attempt} échouée, nouvel essai dans {delay} secondes"
+                )
+                await asyncio.sleep(delay)
+
             if self.sheet is None:
-                logging.error("Impossible de se reconnecter à Google Sheets dans update_surveillance")
+                logging.error(
+                    "Échec de la reconnexion à Google Sheets dans update_surveillance après plusieurs tentatives"
+                )
                 return
             
         try:


### PR DESCRIPTION
## Summary
- Retry Google Sheets reconnection in `update_surveillance` with multiple attempts
- Log each reconnection attempt and failure for easier diagnostics

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689b36cc32ac83238e324caf3a831d12