### PR TITLE
Restart bot automatically after normal shutdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -170,7 +170,7 @@ def main():
             time.sleep(60)
         else:
             logger.info("Le bot s'est arrêté normalement.")
-            break
+            continue
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- Replace `break` with `continue` so the bot restarts after closing

## Testing
- `python - <<'PY' ...` *(simulated `bot.close`)*
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689daaf6664c83238629025779cf0fa9