### PR TITLE
Send daily reminders for inactive scenes

### DIFF
--- a/cogs/Surveillance_scene.py
+++ b/cogs/Surveillance_scene.py
@@ -132,8 +132,6 @@ class SurveillanceScene(commands.Cog):
         # Dernière notification envoyée par salon (channel_id -> timestamp)
         self.last_channel_notifications: Dict[str, float] = {}
 
-        # Cache pour tracker les scènes inactives notifiées (pour éviter spam et détecter retour d'activité)
-        self.notified_inactive_scenes: set = set()
 
         # Caches pour les mises à jour différées
         self.pending_updates: Dict[str, dict] = {}
@@ -274,18 +272,8 @@ class SurveillanceScene(commands.Cog):
                     logging.info(f"Scène {scene_data.get('scene_name', 'Inconnue')}: dernière activité il y a {time_since_activity.days} jours")
 
                     if time_since_activity >= timedelta(days=7):
-                        scene_id = scene_data.get('channel_id')
-                        # Ne notifier que si on ne l'a pas déjà fait
-                        if scene_id not in self.notified_inactive_scenes:
-                            logging.info(f"Scène inactive détectée: {scene_data.get('scene_name', 'Inconnue')}")
-                            await self.notify_inactive_scene(scene_data)
-                            self.notified_inactive_scenes.add(scene_id)
-                    else:
-                        # Scène active, retirer du cache des scènes inactives notifiées
-                        scene_id = scene_data.get('channel_id')
-                        if scene_id in self.notified_inactive_scenes:
-                            self.notified_inactive_scenes.remove(scene_id)
-                            logging.info(f"Scène redevenue active: {scene_data.get('scene_name', 'Inconnue')}")
+                        logging.info(f"Scène inactive détectée: {scene_data.get('scene_name', 'Inconnue')}")
+                        await self.notify_inactive_scene(scene_data)
 
                 except Exception as scene_error:
                     logging.error(f"Erreur lors de la vérification de la scène {scene_data.get('scene_name', 'Inconnue')}: {scene_error}")

--- a/tests/test_surveillance_scene.py
+++ b/tests/test_surveillance_scene.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 import sys, pathlib
+from datetime import datetime, timedelta
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from cogs import Surveillance_scene as ss
@@ -40,4 +41,26 @@ async def test_update_surveillance_logs_error_when_no_sheet(caplog):
     scene.refresh_monitored_scenes.assert_not_called()
     scene.update_all_scenes.assert_not_called()
     assert "Impossible de se reconnecter" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_check_inactive_scenes_notifies_each_day():
+    scene = ss.SurveillanceScene.__new__(ss.SurveillanceScene)
+    scene.sheet = object()
+    scene.paris_tz = ss.PARIS_TZ
+    scene.refresh_monitored_scenes = AsyncMock()
+    inactive_time = datetime.now(scene.paris_tz) - timedelta(days=8)
+    scene.monitored_scenes = {
+        '1': {
+            'channel_id': '123',
+            'last_activity_date': inactive_time.isoformat(),
+            'scene_name': 'Test'
+        }
+    }
+    scene.notify_inactive_scene = AsyncMock()
+
+    await ss.SurveillanceScene.check_inactive_scenes.coro(scene)
+    await ss.SurveillanceScene.check_inactive_scenes.coro(scene)
+
+    assert scene.notify_inactive_scene.await_count == 2
 


### PR DESCRIPTION
## Summary
- Remove notification cache so DMs send each day for scenes inactive 7+ days
- Add regression test ensuring repeated notifications

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dc5c8265c8323a8597d6cca37f7be