### PR TITLE
Async Google Drive downloads for card operations

### DIFF
--- a/cogs/Cards.py
+++ b/cogs/Cards.py
@@ -688,7 +688,7 @@ class Cards(commands.Cog):
                 discovery_index = self.discovery_manager.log_discovery(cat, name, interaction.user.id, interaction.user.display_name)
 
                 # Télécharger l'image
-                file_bytes = self.download_drive_file(file_id)
+                file_bytes = await self.download_drive_file(file_id)
                 if not file_bytes:
                     logger.error(f"[FORUM] Impossible de télécharger l'image pour {name} ({cat})")
                     continue
@@ -732,12 +732,12 @@ class Cards(commands.Cog):
         except Exception as e:
             logger.error(f"[PROGRESS] Erreur lors de la mise à jour du message de progression: {e}")
 
-    def download_drive_file(self, file_id: str) -> bytes | None:
-        """Télécharge un fichier depuis Google Drive."""
+    async def download_drive_file(self, file_id: str) -> bytes | None:
+        """Télécharge un fichier depuis Google Drive de manière asynchrone."""
         try:
             logger.debug(f"[DRIVE] Téléchargement du fichier {file_id}")
             request = self.drive_service.files().get_media(fileId=file_id)
-            file_bytes = request.execute()
+            file_bytes = await asyncio.to_thread(request.execute)
             logger.debug(f"[DRIVE] Fichier téléchargé avec succès: {len(file_bytes)} bytes")
             return file_bytes
         except Exception as e:
@@ -896,7 +896,7 @@ class Cards(commands.Cog):
                             break
                     else:
                         # Toutes les cartes ont été retirées avec succès, procéder à l'ajout de la carte Full
-                        file_bytes = self.download_drive_file(file_id)
+                        file_bytes = await self.download_drive_file(file_id)
                         if not file_bytes:
                             logger.error(f"[UPGRADE] Impossible de télécharger l'image pour {full_name}")
                             # Rollback: remettre les cartes retirées

--- a/cogs/cards/forum.py
+++ b/cogs/cards/forum.py
@@ -460,7 +460,7 @@ class ForumManager:
                 try:
                     if drive_service:
                         # Télécharger l'image depuis Google Drive
-                        file_bytes = self._download_drive_file(drive_service, file_id)
+                        file_bytes = await self._download_drive_file(drive_service, file_id)
                         if not file_bytes:
                             logging.error(f"[FORUM] Impossible de télécharger {name} ({cat})")
                             error_count += 1
@@ -506,9 +506,9 @@ class ForumManager:
             logging.error(f"[FORUM] Erreur lors de la population du forum: {e}")
             return 0, 0
 
-    def _download_drive_file(self, drive_service, file_id: str) -> bytes:
+    async def _download_drive_file(self, drive_service, file_id: str) -> bytes | None:
         """
-        Télécharge un fichier depuis Google Drive.
+        Télécharge un fichier depuis Google Drive de manière asynchrone.
 
         Args:
             drive_service: Service Google Drive
@@ -519,7 +519,7 @@ class ForumManager:
         """
         try:
             request = drive_service.files().get_media(fileId=file_id)
-            file_bytes = request.execute()
+            file_bytes = await asyncio.to_thread(request.execute)
             return file_bytes
         except Exception as e:
             logging.error(f"[FORUM] Erreur lors du téléchargement du fichier {file_id}: {e}")
@@ -627,7 +627,7 @@ class ForumManager:
                 try:
                     if drive_service:
                         logging.info(f"[FORUM] Téléchargement de {name} (ID: {file_id})")
-                        file_bytes = self._download_drive_file(drive_service, file_id)
+                        file_bytes = await self._download_drive_file(drive_service, file_id)
                         if not file_bytes:
                             logging.error(f"[FORUM] Impossible de télécharger {name} ({cat}) - fichier vide")
                             error_count += 1

--- a/cogs/cards/views/menu_views.py
+++ b/cogs/cards/views/menu_views.py
@@ -159,7 +159,7 @@ class CardsMenuView(discord.ui.View):
                 None,
             )
             if file_id:
-                file_bytes = self.cog.download_drive_file(file_id)
+                file_bytes = await self.cog.download_drive_file(file_id)
                 if file_bytes:
                     embed, image_file = self.cog.build_card_embed(cat, name, file_bytes, self.user)
                     embed_msgs.append((embed, image_file))
@@ -229,7 +229,7 @@ class CardsMenuView(discord.ui.View):
                     None,
                 )
                 if file_id:
-                    file_bytes = self.cog.download_drive_file(file_id)
+                    file_bytes = await self.cog.download_drive_file(file_id)
                     if file_bytes:
                         embed, image_file = self.cog.build_card_embed(cat, name, file_bytes, self.user)
                         embed_msgs.append((embed, image_file))
@@ -548,7 +548,7 @@ class SacrificialDrawConfirmationView(discord.ui.View):
                         None,
                     )
                     if file_id:
-                        file_bytes = self.cog.download_drive_file(file_id)
+                        file_bytes = await self.cog.download_drive_file(file_id)
                         if file_bytes:
                             embed, image_file = self.cog.build_card_embed(cat, name, file_bytes, self.user)
                             embed_msgs.append((embed, image_file))


### PR DESCRIPTION
## Summary
- Convert `download_drive_file` to async using `asyncio.to_thread`
- Await image downloads in menu views and forum utilities to keep bot responsive
- Make forum manager's drive downloads asynchronous

## Testing
- `python -m py_compile cogs/Cards.py cogs/cards/views/menu_views.py cogs/cards/forum.py`
- `pip install pytest-asyncio`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0ab871bb8832393d087b058286d23